### PR TITLE
feat : post 페이징 기능 추가

### DIFF
--- a/src/main/java/com/masil/domain/post/controller/PostController.java
+++ b/src/main/java/com/masil/domain/post/controller/PostController.java
@@ -9,11 +9,15 @@ import com.masil.domain.post.dto.PostsResponse;
 import com.masil.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.net.URI;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,10 +39,11 @@ public class PostController {
 
     // 목록 조회
     @GetMapping("/{boardId}/posts")
-    public ResponseEntity<PostsResponse> findAllPost(@PathVariable Long boardId) {
+    public ResponseEntity<PostsResponse> findAllPost(@PathVariable Long boardId,
+                                                     @PageableDefault(sort = "createDate", direction = DESC) Pageable pageable) {
         log.info("게시글 목록 조회 시작");
 
-        PostsResponse postsResponse = postService.findAllPost();
+        PostsResponse postsResponse = postService.findAllPost(boardId, pageable);
         return ResponseEntity.ok(postsResponse);
     }
 

--- a/src/main/java/com/masil/domain/post/dto/PostsResponse.java
+++ b/src/main/java/com/masil/domain/post/dto/PostsResponse.java
@@ -2,6 +2,7 @@ package com.masil.domain.post.dto;
 
 import com.masil.domain.post.entity.Post;
 import lombok.Getter;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -10,16 +11,18 @@ import java.util.stream.Collectors;
 public class PostsResponse {
 
     private List<PostsElementResponse> posts;
+    private Boolean isLast;
 
-    public PostsResponse(List<PostsElementResponse> posts) {
+    public PostsResponse(List<PostsElementResponse> posts, boolean isLast) {
         this.posts = posts;
+        this.isLast = isLast;
     }
-    public static PostsResponse ofPosts(List<Post> posts) {
+    public static PostsResponse ofPosts(Slice<Post> posts) {
         List<PostsElementResponse> postsResponse = posts
                 .stream()
                 .map((Post post) -> PostsElementResponse.of(post))
                 .collect(Collectors.toList());
 
-        return new PostsResponse(postsResponse);
+        return new PostsResponse(postsResponse, posts.isLast());
     }
 }

--- a/src/main/java/com/masil/domain/post/service/PostService.java
+++ b/src/main/java/com/masil/domain/post/service/PostService.java
@@ -12,11 +12,12 @@ import com.masil.domain.postlike.repository.PostLikeRepository;
 import com.masil.global.error.exception.BusinessException;
 import com.masil.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -40,8 +41,8 @@ public class PostService {
         return PostDetailResponse.of(post, isOwner, isLike);
     }
 
-    public PostsResponse findAllPost() {
-        List<Post> posts = postRepository.findAll();
+    public PostsResponse findAllPost(Long boardId, Pageable pageable) {
+        Slice<Post> posts = postRepository.findAll(pageable);
         return PostsResponse.ofPosts(posts);
     }
 

--- a/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
@@ -144,7 +144,7 @@ public class PostControllerTest {
     void t3() throws Exception {
         // given
         List<PostsElementResponse> postsElementResponseList = new ArrayList<>();
-        for (int i = 1; i <= 2; i++) {
+        for (int i = 2; i >= 1; i--) {
             postsElementResponseList.add(PostsElementResponse.builder()
                     .id((long) i)
                     .member(MEMBER_RESPONSE)
@@ -157,9 +157,9 @@ public class PostControllerTest {
                     .build());
         }
 
-        PostsResponse postsResponse = new PostsResponse(postsElementResponseList);
+        PostsResponse postsResponse = new PostsResponse(postsElementResponseList, true);
 
-        given(postService.findAllPost()).willReturn(postsResponse);
+        given(postService.findAllPost(any(), any())).willReturn(postsResponse);
 
         // when
         ResultActions resultActions = requestFindAllPost();
@@ -188,19 +188,12 @@ public class PostControllerTest {
                                 fieldWithPath("posts.[].likeCount").description("좋아요 개수"),
                                 fieldWithPath("posts.[].commentCount").description("댓글 개수"),
                                 fieldWithPath("posts.[].createDate").description("생성 날짜"),
-                                fieldWithPath("posts.[].modifyDate").description("수정 날짜")
+                                fieldWithPath("posts.[].modifyDate").description("수정 날짜"),
+                                fieldWithPath("isLast").description("마지막 페이지 여부")
                         )
                 ));
     }
-//    private Long id;
-//    private Long memberId;
-//    private String nickname;
-//    private String content;  // 글자 제한
-//    private int viewCount;
-//    private int likeCount;
-//    private int commentCount;
-//    private LocalDateTime createDate;
-//    private LocalDateTime modifyDate;
+
     @Test
     @DisplayName("게시글 수정")
     void t4() throws Exception {
@@ -258,7 +251,7 @@ public class PostControllerTest {
     }
 
     private ResultActions requestFindAllPost() throws Exception {
-        return mockMvc.perform(get("/boards/1/posts/")
+        return mockMvc.perform(get("/boards/1/posts?page=0&size=20")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print());

--- a/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
@@ -93,7 +93,7 @@ public class PostControllerTest {
         given(postService.createPost(any(), any())).willReturn(1L);
 
         // when
-        ResultActions resultActions = requestCreatePost(postCreateRequest);
+        ResultActions resultActions = requestCreatePost("/boards/1/posts", postCreateRequest);
 
         // then
         resultActions
@@ -116,7 +116,7 @@ public class PostControllerTest {
         given(postService.findDetailPost(any(), any())).willReturn(POST_RESPONSE_1);
 
         // when
-        ResultActions resultActions = requestFindPost();
+        ResultActions resultActions = requestFindPost("/boards/1/posts/1");
 
         // then
         resultActions
@@ -162,7 +162,7 @@ public class PostControllerTest {
         given(postService.findAllPost(any(), any())).willReturn(postsResponse);
 
         // when
-        ResultActions resultActions = requestFindAllPost();
+        ResultActions resultActions = requestFindAllPost("/boards/1/posts?page=0&size=20");
 
         // then
         resultActions
@@ -203,7 +203,7 @@ public class PostControllerTest {
         willDoNothing().given(postService).modifyPost(any(),any(),any());
 
         // when
-        ResultActions resultActions = requestModifyPost(postModifyRequest);
+        ResultActions resultActions = requestModifyPost("/boards/1/posts/1" ,postModifyRequest);
 
         // then
         resultActions
@@ -224,7 +224,7 @@ public class PostControllerTest {
         // given
         willDoNothing().given(postService).deletePost(any(), any());
         // when
-        ResultActions resultActions = requestDeletePost();
+        ResultActions resultActions = requestDeletePost("/boards/1/posts/1");
 
         // then
         resultActions
@@ -235,36 +235,36 @@ public class PostControllerTest {
         ));
     }
 
-    private ResultActions requestCreatePost(PostCreateRequest dto) throws Exception {
-        return mockMvc.perform(post("/boards/1/posts")
+    private ResultActions requestCreatePost(String url, PostCreateRequest dto) throws Exception {
+        return mockMvc.perform(post(url)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
                 .andDo(print());
     }
 
-    private ResultActions requestFindPost() throws Exception {
-        return mockMvc.perform(get("/boards/1/posts/1")
+    private ResultActions requestFindPost(String url) throws Exception {
+        return mockMvc.perform(get(url)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print());
     }
 
-    private ResultActions requestFindAllPost() throws Exception {
-        return mockMvc.perform(get("/boards/1/posts?page=0&size=20")
+    private ResultActions requestFindAllPost(String url) throws Exception {
+        return mockMvc.perform(get(url)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print());
     }
-    private ResultActions requestModifyPost(PostModifyRequest dto) throws Exception {
-        return mockMvc.perform(patch("/boards/1/posts/1")
+    private ResultActions requestModifyPost(String url, PostModifyRequest dto) throws Exception {
+        return mockMvc.perform(patch(url)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
                 .andDo(print());
     }
-    private ResultActions requestDeletePost() throws Exception {
-        return mockMvc.perform(delete("/boards/1/posts/1")
+    private ResultActions requestDeletePost(String url) throws Exception {
+        return mockMvc.perform(delete(url)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print());

--- a/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
@@ -2,9 +2,7 @@ package com.masil.domain.post.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.masil.domain.member.dto.response.MemberResponse;
-import com.masil.domain.member.entity.Member;
 import com.masil.domain.post.dto.*;
-import com.masil.domain.post.entity.Post;
 import com.masil.domain.post.service.PostService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -42,6 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureRestDocs
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
+@MockBean(JpaMetamodelMappingContext.class)
 public class PostControllerTest {
 
     @Autowired

--- a/src/test/java/com/masil/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/masil/domain/post/service/PostServiceTest.java
@@ -12,11 +12,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 
-import java.time.LocalDateTime;
+import java.awt.print.Pageable;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 public class PostServiceTest extends ServiceTest {
 
@@ -102,8 +105,10 @@ public class PostServiceTest extends ServiceTest {
     void findAllPost_success() {
 
         // when
-        PostsResponse allPost = postService.findAllPost();
-        PostsElementResponse postsElementResponse = allPost.getPosts().get(0);
+        PostsResponse allPost = postService.findAllPost(1L, PageRequest.of(0, 20, DESC, "createDate"));
+        List<PostsElementResponse> postList = allPost.getPosts();
+        PostsElementResponse postsElementResponse = postList.get(postList.size()-1);
+
         // then
         assertThat(allPost.getPosts().size()).isEqualTo(2);
         assertThat(postsElementResponse.getId()).isEqualTo(1L);


### PR DESCRIPTION
# 작업 내용
게시글 목록 요청에 페이징 기능을 추가하였습니다. 
spring에 페이징 관련 기능이 잘 갖추어져 있어 쉽게 구현할 수 있었습니다.

db에 날짜를 자동으로 추가해주기 위해 MasilApplication 클래스에 @EnableJpaAuditing 을 추가시켜주었는데 
이로 인해 controller test 부분에 버그가 발생하였습니다.
https://1-7171771.tistory.com/136
해당 블로그 보고 고쳤습니다.

# 참고 사항
https://tecoble.techcourse.co.kr/post/2021-08-15-pageable/

Closes 이슈번호
#23 
