### PR TITLE
feat : 글로벌 예외 수정 + post 관련 예외 추가 

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -7,11 +7,11 @@
 :sectlinks:
 
 [[resources-post]]
-= 게시글
+= 1. 게시글
 
-== 1. 글 상세 보기
+== 1.1. 게시글 상세 보기
 
-=== 1.1 글 상세 보기 성공
+=== 1.1.1 게시글 상세 보기 성공
 
 ==== HTTP request
 
@@ -21,9 +21,20 @@ include::{snippets}/post/findOne/http-request.adoc[]
 
 include::{snippets}/post/findOne/http-response.adoc[]
 
-== 2. 글 목록 보기
+=== 1.1.2 존재하지 않는 게시글인 경우
 
-=== 2.1 글 목록 보기 성공
+==== HTTP request
+
+include::{snippets}/post/findOne/notFound/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/post/findOne/notFound/http-response.adoc[]
+
+
+== 1.2. 게시글 목록 보기
+
+=== 1.2.1 게시글 목록 보기 성공
 
 ==== HTTP request
 
@@ -33,9 +44,9 @@ include::{snippets}/post/findAll/http-request.adoc[]
 
 include::{snippets}/post/findAll/http-response.adoc[]
 
-== 3. 글 생성 하기
+== 1.3. 게시글 생성 하기
 
-=== 3.1 글 생성 하기 성공
+=== 1.3. 게시글 생성 하기 성공
 
 ==== HTTP request
 
@@ -45,9 +56,9 @@ include::{snippets}/post/create/http-request.adoc[]
 
 include::{snippets}/post/create/http-response.adoc[]
 
-== 4. 글 수정 하기
+== 1.4. 게시글 수정 하기
 
-=== 4.1 글 수정 하기 성공
+=== 1.4.1 게시글 수정 하기 성공
 
 ==== HTTP request
 
@@ -57,9 +68,19 @@ include::{snippets}/post/modify/http-request.adoc[]
 
 include::{snippets}/post/modify/http-response.adoc[]
 
-== 5. 글 삭제 하기
+=== 1.4.2 게시글 수정 권한 없음
 
-=== 5.1 글 삭제 하기 성공
+==== HTTP request
+
+include::{snippets}/post/modify/access-denied/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/post/modify/access-denied/http-response.adoc[]
+
+== 1.5. 게시글 삭제 하기
+
+=== 1.5.1 게시글 삭제 하기 성공
 
 ==== HTTP request
 
@@ -68,3 +89,35 @@ include::{snippets}/post/delete/http-request.adoc[]
 ==== HTTP response
 
 include::{snippets}/post/delete/http-response.adoc[]
+
+=== 1.5.2 게시글 삭제 권한 없음
+
+==== HTTP request
+
+include::{snippets}/post/delete/access_denied/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/post/delete/access_denied/http-response.adoc[]
+
+== 1.6. 게시글 좋아요
+
+=== 1.6.1 게시글 좋아요 성공
+
+==== HTTP request
+
+include::{snippets}/post/like/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/post/like/http-response.adoc[]
+
+=== 1.6.2 본인 글에 좋아요하는 경우
+
+==== HTTP request
+
+include::{snippets}/post/like/selfLike/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/post/like/selfLike/http-response.adoc[]

--- a/src/main/java/com/masil/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/masil/domain/member/exception/MemberNotFoundException.java
@@ -1,0 +1,11 @@
+package com.masil.domain.member.exception;
+
+import com.masil.global.error.exception.EntityNotFoundException;
+import com.masil.global.error.exception.ErrorCode;
+
+public class MemberNotFoundException extends EntityNotFoundException {
+
+    public MemberNotFoundException() {
+        super(ErrorCode.MEMBER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/masil/domain/post/exception/PostAccessDeniedException.java
+++ b/src/main/java/com/masil/domain/post/exception/PostAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.masil.domain.post.exception;
+
+import com.masil.global.error.exception.ErrorCode;
+import com.masil.global.error.exception.NoAuthenticationException;
+
+public class PostAccessDeniedException extends NoAuthenticationException {
+    public PostAccessDeniedException() {
+        super(ErrorCode.POST_ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/masil/domain/post/exception/PostNotFoundException.java
+++ b/src/main/java/com/masil/domain/post/exception/PostNotFoundException.java
@@ -1,10 +1,11 @@
 package com.masil.domain.post.exception;
 
-public class PostNotFoundException extends RuntimeException {
+import com.masil.global.error.exception.EntityNotFoundException;
+import com.masil.global.error.exception.ErrorCode;
 
-    private static final String MESSAGE = "게시물을 찾을 수 없습니다.";
+public class PostNotFoundException extends EntityNotFoundException {
 
     public PostNotFoundException() {
-        super(MESSAGE);
+        super(ErrorCode.POST_NOT_FOUND);
     }
 }

--- a/src/main/java/com/masil/domain/post/service/PostService.java
+++ b/src/main/java/com/masil/domain/post/service/PostService.java
@@ -1,8 +1,10 @@
 package com.masil.domain.post.service;
 
+import com.masil.domain.member.exception.MemberNotFoundException;
 import com.masil.domain.post.dto.*;
 
 import com.masil.domain.post.entity.Post;
+import com.masil.domain.post.exception.PostAccessDeniedException;
 import com.masil.domain.post.exception.PostNotFoundException;
 import com.masil.domain.post.repository.PostRepository;
 import com.masil.domain.member.entity.Member;
@@ -73,7 +75,7 @@ public class PostService {
 
     private void validateOwner(Long memberId, Post post) {
         if (!post.isOwner(memberId)) {
-            throw new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED); // 추후 변경
+            throw new PostAccessDeniedException();
         }
     }
 
@@ -84,6 +86,6 @@ public class PostService {
 
     private Member findMemberById(Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(RuntimeException::new);
+                .orElseThrow(MemberNotFoundException::new);
     }
 }

--- a/src/main/java/com/masil/domain/postlike/exception/SelfPostLikeException.java
+++ b/src/main/java/com/masil/domain/postlike/exception/SelfPostLikeException.java
@@ -1,0 +1,10 @@
+package com.masil.domain.postlike.exception;
+
+import com.masil.global.error.exception.ErrorCode;
+import com.masil.global.error.exception.NoAuthenticationException;
+
+public class SelfPostLikeException extends NoAuthenticationException {
+    public SelfPostLikeException() {
+        super(ErrorCode.POST_NOT_SELF_LIKE);
+    }
+}

--- a/src/main/java/com/masil/domain/postlike/service/PostLikeService.java
+++ b/src/main/java/com/masil/domain/postlike/service/PostLikeService.java
@@ -1,18 +1,18 @@
 package com.masil.domain.postlike.service;
 
 import com.masil.domain.member.entity.Member;
+import com.masil.domain.member.exception.MemberNotFoundException;
 import com.masil.domain.member.repository.MemberRepository;
 import com.masil.domain.post.entity.Post;
 import com.masil.domain.post.exception.PostNotFoundException;
 import com.masil.domain.post.repository.PostRepository;
 import com.masil.domain.postlike.dto.PostLikeResponse;
 import com.masil.domain.postlike.entity.PostLike;
+import com.masil.domain.postlike.exception.SelfPostLikeException;
 import com.masil.domain.postlike.repository.PostLikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -29,7 +29,7 @@ public class PostLikeService {
         Member member = findMemberById(memberId);
 
         if (post.isOwner(memberId)) {
-            throw new RuntimeException("본인 글에는 좋아요를 누를 수 없습니다."); // 추후 변경
+            throw new SelfPostLikeException(); // 추후 변경
         }
 
         PostLike postLike = postLikeRepository.findByPostAndMember(post, member).orElse(null);
@@ -56,7 +56,7 @@ public class PostLikeService {
     }
     private Member findMemberById(Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(RuntimeException::new);
+                .orElseThrow(MemberNotFoundException::new);
     }
     
 }

--- a/src/main/java/com/masil/global/error/ErrorResponse.java
+++ b/src/main/java/com/masil/global/error/ErrorResponse.java
@@ -18,21 +18,18 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ErrorResponse {
     private String message;
-    private int status;
     private List<FieldError> errors;
-    private String code;
+    private int code;
 
 
     private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
         this.message = code.getMessage();
-        this.status = code.getStatus();
         this.errors = errors;
         this.code = code.getCode();
     }
 
     private ErrorResponse(final ErrorCode code) {
         this.message = code.getMessage();
-        this.status = code.getStatus();
         this.code = code.getCode();
         this.errors = new ArrayList<>();
     }

--- a/src/main/java/com/masil/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/masil/global/error/GlobalExceptionHandler.java
@@ -19,72 +19,72 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    /**
-     * javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다.
-     * HttpMessageConverter 에서 등록한 HttpMessageConverter binding 못할경우 발생
-     * 주로 @RequestBody, @RequestPart 어노테이션에서 발생
-     */
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        log.error("handleMethodArgumentNotValidException", e);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-    }
-
-    /**
-     * @ModelAttribut 으로 binding error 발생시 BindException 발생한다.
-     * ref https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-ann-modelattrib-method-args
-     */
-    @ExceptionHandler(BindException.class)
-    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
-        log.error("handleBindException", e);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-    }
-
-    /**
-     * enum type 일치하지 않아 binding 못할 경우 발생
-     * 주로 @RequestParam enum으로 binding 못했을 경우 발생
-     */
-    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
-        log.error("handleMethodArgumentTypeMismatchException", e);
-        final ErrorResponse response = ErrorResponse.of(e);
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-    }
-
-    /**
-     * 지원하지 않은 HTTP method 호출 할 경우 발생
-     */
-    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
-        log.error("handleHttpRequestMethodNotSupportedException", e);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
-        return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
-    }
-
-    /**
-     * Authentication 객체가 필요한 권한을 보유하지 않은 경우 발생합
-     */
-    @ExceptionHandler(AccessDeniedException.class)
-    protected ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
-        log.error("handleAccessDeniedException", e);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.HANDLE_ACCESS_DENIED);
-        return new ResponseEntity<>(response, HttpStatus.valueOf(ErrorCode.HANDLE_ACCESS_DENIED.getStatus()));
-    }
-
-    @ExceptionHandler(BusinessException.class)
-    protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
-        log.error("handleEntityNotFoundException", e);
-        final ErrorCode errorCode = e.getErrorCode();
-        final ErrorResponse response = ErrorResponse.of(errorCode);
-        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
-    }
-
-    @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
-        log.error("handleEntityNotFoundException", e);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
-        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
-    }
+//    /**
+//     * javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다.
+//     * HttpMessageConverter 에서 등록한 HttpMessageConverter binding 못할경우 발생
+//     * 주로 @RequestBody, @RequestPart 어노테이션에서 발생
+//     */
+//    @ExceptionHandler(MethodArgumentNotValidException.class)
+//    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+//        log.error("handleMethodArgumentNotValidException", e);
+//        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
+//        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+//    }
+//
+//    /**
+//     * @ModelAttribut 으로 binding error 발생시 BindException 발생한다.
+//     * ref https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-ann-modelattrib-method-args
+//     */
+//    @ExceptionHandler(BindException.class)
+//    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+//        log.error("handleBindException", e);
+//        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
+//        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+//    }
+//
+//    /**
+//     * enum type 일치하지 않아 binding 못할 경우 발생
+//     * 주로 @RequestParam enum으로 binding 못했을 경우 발생
+//     */
+//    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+//    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+//        log.error("handleMethodArgumentTypeMismatchException", e);
+//        final ErrorResponse response = ErrorResponse.of(e);
+//        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+//    }
+//
+//    /**
+//     * 지원하지 않은 HTTP method 호출 할 경우 발생
+//     */
+//    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+//    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+//        log.error("handleHttpRequestMethodNotSupportedException", e);
+//        final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+//        return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
+//    }
+//
+//    /**
+//     * Authentication 객체가 필요한 권한을 보유하지 않은 경우 발생합
+//     */
+//    @ExceptionHandler(AccessDeniedException.class)
+//    protected ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+//        log.error("handleAccessDeniedException", e);
+//        final ErrorResponse response = ErrorResponse.of(ErrorCode.HANDLE_ACCESS_DENIED);
+//        return new ResponseEntity<>(response, HttpStatus.valueOf(ErrorCode.HANDLE_ACCESS_DENIED.getStatus()));
+//    }
+//
+//    @ExceptionHandler(BusinessException.class)
+//    protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+//        log.error("handleEntityNotFoundException", e);
+//        final ErrorCode errorCode = e.getErrorCode();
+//        final ErrorResponse response = ErrorResponse.of(errorCode);
+//        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+//    }
+//
+//    @ExceptionHandler(Exception.class)
+//    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+//        log.error("handleEntityNotFoundException", e);
+//        final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+//        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+//    }
 }

--- a/src/main/java/com/masil/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/masil/global/error/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.masil.global.error;
 import com.masil.global.error.exception.BusinessException;
 import com.masil.global.error.exception.EntityNotFoundException;
 import com.masil.global.error.exception.ErrorCode;
+import com.masil.global.error.exception.NoAuthenticationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -88,6 +89,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(EntityNotFoundException.class)
     protected ResponseEntity<ErrorResponse> handleEntityNotFoundException(final EntityNotFoundException e) {
         log.error("handleEntityNotFoundException", e);
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(response);
+    }
+
+    @ExceptionHandler(NoAuthenticationException.class)
+    protected ResponseEntity<ErrorResponse> handleNoAuthenticationException(final NoAuthenticationException e) {
+        log.error("handleNoAuthenticationException", e);
         final ErrorCode errorCode = e.getErrorCode();
         final ErrorResponse response = ErrorResponse.of(errorCode);
         return ResponseEntity.status(errorCode.getStatus())

--- a/src/main/java/com/masil/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/masil/global/error/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.masil.global.error;
 
 import com.masil.global.error.exception.BusinessException;
+import com.masil.global.error.exception.EntityNotFoundException;
 import com.masil.global.error.exception.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -19,72 +20,84 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-//    /**
-//     * javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다.
-//     * HttpMessageConverter 에서 등록한 HttpMessageConverter binding 못할경우 발생
-//     * 주로 @RequestBody, @RequestPart 어노테이션에서 발생
-//     */
-//    @ExceptionHandler(MethodArgumentNotValidException.class)
-//    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-//        log.error("handleMethodArgumentNotValidException", e);
-//        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
-//        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-//    }
-//
-//    /**
-//     * @ModelAttribut 으로 binding error 발생시 BindException 발생한다.
-//     * ref https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-ann-modelattrib-method-args
-//     */
-//    @ExceptionHandler(BindException.class)
-//    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
-//        log.error("handleBindException", e);
-//        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
-//        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-//    }
-//
-//    /**
-//     * enum type 일치하지 않아 binding 못할 경우 발생
-//     * 주로 @RequestParam enum으로 binding 못했을 경우 발생
-//     */
-//    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-//    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
-//        log.error("handleMethodArgumentTypeMismatchException", e);
-//        final ErrorResponse response = ErrorResponse.of(e);
-//        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-//    }
-//
-//    /**
-//     * 지원하지 않은 HTTP method 호출 할 경우 발생
-//     */
-//    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-//    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
-//        log.error("handleHttpRequestMethodNotSupportedException", e);
-//        final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
-//        return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
-//    }
-//
-//    /**
-//     * Authentication 객체가 필요한 권한을 보유하지 않은 경우 발생합
-//     */
-//    @ExceptionHandler(AccessDeniedException.class)
-//    protected ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
-//        log.error("handleAccessDeniedException", e);
-//        final ErrorResponse response = ErrorResponse.of(ErrorCode.HANDLE_ACCESS_DENIED);
-//        return new ResponseEntity<>(response, HttpStatus.valueOf(ErrorCode.HANDLE_ACCESS_DENIED.getStatus()));
-//    }
-//
-//    @ExceptionHandler(BusinessException.class)
-//    protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
-//        log.error("handleEntityNotFoundException", e);
-//        final ErrorCode errorCode = e.getErrorCode();
-//        final ErrorResponse response = ErrorResponse.of(errorCode);
-//        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
-//    }
-//
-//    @ExceptionHandler(Exception.class)
-//    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
-//        log.error("handleEntityNotFoundException", e);
-//        final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
-//        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
-//    }
+    /**
+     * javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다.
+     * HttpMessageConverter 에서 등록한 HttpMessageConverter binding 못할경우 발생
+     * 주로 @RequestBody, @RequestPart 어노테이션에서 발생
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("handleMethodArgumentNotValidException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    /**
+     * @ModelAttribut 으로 binding error 발생시 BindException 발생한다.
+     * ref https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-ann-modelattrib-method-args
+     */
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        log.error("handleBindException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    /**
+     * enum type 일치하지 않아 binding 못할 경우 발생
+     * 주로 @RequestParam enum으로 binding 못했을 경우 발생
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("handleMethodArgumentTypeMismatchException", e);
+        final ErrorResponse response = ErrorResponse.of(e);
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    /**
+     * 지원하지 않은 HTTP method 호출 할 경우 발생
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+                .body(response);
+    }
+
+    /**
+     * Authentication 객체가 필요한 권한을 보유하지 않은 경우 발생합
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("handleAccessDeniedException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.HANDLE_ACCESS_DENIED);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(response);
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+        log.error("handleEntityNotFoundException", e);
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(response);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleEntityNotFoundException(final EntityNotFoundException e) {
+        log.error("handleEntityNotFoundException", e);
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("handleException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.SERVER_ERROR);
+        return ResponseEntity.internalServerError().body(response);
+    }
 }

--- a/src/main/java/com/masil/global/error/exception/EntityNotFoundException.java
+++ b/src/main/java/com/masil/global/error/exception/EntityNotFoundException.java
@@ -4,4 +4,8 @@ public class EntityNotFoundException extends BusinessException{
     public EntityNotFoundException(String message) {
         super(message, ErrorCode.ENTITY_NOT_FOUND);
     }
+
+    public EntityNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
 }

--- a/src/main/java/com/masil/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/masil/global/error/exception/ErrorCode.java
@@ -9,8 +9,9 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(BAD_REQUEST, 1001, " Invalid Input Value"),
     ENTITY_NOT_FOUND(BAD_REQUEST, 1002, " Entity Not Found"),
     SERVER_ERROR(INTERNAL_SERVER_ERROR, 1003, "Server Error"),
-    INVALID_TYPE_VALUE(BAD_REQUEST, 1004, " Invalid Type Value"),
-    HANDLE_ACCESS_DENIED(FORBIDDEN, 1005, "Access is Denied"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 1004, "method not allowed"),
+    INVALID_TYPE_VALUE(BAD_REQUEST, 1005, " Invalid Type Value"),
+    HANDLE_ACCESS_DENIED(FORBIDDEN, 1006, "Access is Denied"),
 
     ;
 

--- a/src/main/java/com/masil/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/masil/global/error/exception/ErrorCode.java
@@ -1,21 +1,24 @@
 package com.masil.global.error.exception;
 
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
 public enum ErrorCode {
     // Common
-    INVALID_INPUT_VALUE(400, "C001", " Invalid Input Value"),
-    METHOD_NOT_ALLOWED(405, "C002", " Invalid Input Value"),
-    ENTITY_NOT_FOUND(400, "C003", " Entity Not Found"),
-    INTERNAL_SERVER_ERROR(500, "C004", "Server Error"),
-    INVALID_TYPE_VALUE(400, "C005", " Invalid Type Value"),
-    HANDLE_ACCESS_DENIED(403, "C006", "Access is Denied"),
+    INVALID_INPUT_VALUE(BAD_REQUEST, 1001, " Invalid Input Value"),
+    ENTITY_NOT_FOUND(BAD_REQUEST, 1002, " Entity Not Found"),
+    SERVER_ERROR(INTERNAL_SERVER_ERROR, 1003, "Server Error"),
+    INVALID_TYPE_VALUE(BAD_REQUEST, 1004, " Invalid Type Value"),
+    HANDLE_ACCESS_DENIED(FORBIDDEN, 1005, "Access is Denied"),
 
     ;
 
-    private final String code;
+    private HttpStatus status;
+    private final int code;
     private final String message;
-    private int status;
 
-    ErrorCode(final int status, final String code, final String message) {
+    ErrorCode(final HttpStatus status, final int code, final String message) {
         this.status = status;
         this.message = message;
         this.code = code;
@@ -25,11 +28,11 @@ public enum ErrorCode {
         return this.message;
     }
 
-    public String getCode() {
+    public int getCode() {
         return code;
     }
 
-    public int getStatus() {
+    public HttpStatus getStatus() {
         return status;
     }
 

--- a/src/main/java/com/masil/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/masil/global/error/exception/ErrorCode.java
@@ -13,6 +13,15 @@ public enum ErrorCode {
     INVALID_TYPE_VALUE(BAD_REQUEST, 1005, " Invalid Type Value"),
     HANDLE_ACCESS_DENIED(FORBIDDEN, 1006, "Access is Denied"),
 
+    // member
+    MEMBER_NOT_FOUND(NOT_FOUND, 2001, "존재하지 않는 사용자입니다."),
+
+    // post
+    POST_NOT_FOUND(NOT_FOUND, 3001, "존재하지 않는 게시글입니다."),
+    POST_ACCESS_DENIED(FORBIDDEN, 3002, "해당 게시글에 대한 권한이 없습니다"),
+
+    // post like
+    POST_NOT_SELF_LIKE(FORBIDDEN, 4001, "본인 글에는 좋아요를 누를 수 없습니다.")
     ;
 
     private HttpStatus status;

--- a/src/main/java/com/masil/global/error/exception/NoAuthenticationException.java
+++ b/src/main/java/com/masil/global/error/exception/NoAuthenticationException.java
@@ -1,0 +1,12 @@
+package com.masil.global.error.exception;
+
+public class NoAuthenticationException extends BusinessException{
+
+    public NoAuthenticationException(String message) {
+        super(message, ErrorCode.HANDLE_ACCESS_DENIED);
+    }
+
+    public NoAuthenticationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -448,36 +448,40 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel0">
-<li><a href="#resources-post">게시글</a>
+<li><a href="#resources-post">1. 게시글</a>
 <ul class="sectlevel1">
-<li><a href="#_1_게시글_상세_보기">1. 게시글 상세 보기</a>
+<li><a href="#_1_1_게시글_상세_보기">1.1. 게시글 상세 보기</a>
 <ul class="sectlevel2">
-<li><a href="#_1_1_게시글_상세_보기_성공">1.1 게시글 상세 보기 성공</a></li>
+<li><a href="#_1_1_1_게시글_상세_보기_성공">1.1.1 게시글 상세 보기 성공</a></li>
+<li><a href="#_1_1_2_존재하지_않는_게시글인_경우">1.1.2 존재하지 않는 게시글인 경우</a></li>
 </ul>
 </li>
-<li><a href="#_2_게시글_목록_보기">2. 게시글 목록 보기</a>
+<li><a href="#_1_2_게시글_목록_보기">1.2. 게시글 목록 보기</a>
 <ul class="sectlevel2">
-<li><a href="#_2_1_게시글_목록_보기_성공">2.1 게시글 목록 보기 성공</a></li>
+<li><a href="#_1_2_1_게시글_목록_보기_성공">1.2.1 게시글 목록 보기 성공</a></li>
 </ul>
 </li>
-<li><a href="#_3_게시글_생성_하기">3. 게시글 생성 하기</a>
+<li><a href="#_1_3_게시글_생성_하기">1.3. 게시글 생성 하기</a>
 <ul class="sectlevel2">
-<li><a href="#_3_1_게시글_생성_하기_성공">3.1 게시글 생성 하기 성공</a></li>
+<li><a href="#_1_3_게시글_생성_하기_성공">1.3. 게시글 생성 하기 성공</a></li>
 </ul>
 </li>
-<li><a href="#_4_게시글_수정_하기">4. 게시글 수정 하기</a>
+<li><a href="#_1_4_게시글_수정_하기">1.4. 게시글 수정 하기</a>
 <ul class="sectlevel2">
-<li><a href="#_4_1_게시글_수정_하기_성공">4.1 게시글 수정 하기 성공</a></li>
+<li><a href="#_1_4_1_게시글_수정_하기_성공">1.4.1 게시글 수정 하기 성공</a></li>
+<li><a href="#_1_4_2_게시글_수정_권한_없음">1.4.2 게시글 수정 권한 없음</a></li>
 </ul>
 </li>
-<li><a href="#_5_게시글_삭제_하기">5. 게시글 삭제 하기</a>
+<li><a href="#_1_5_게시글_삭제_하기">1.5. 게시글 삭제 하기</a>
 <ul class="sectlevel2">
-<li><a href="#_5_1_게시글_삭제_하기_성공">5.1 게시글 삭제 하기 성공</a></li>
+<li><a href="#_1_5_1_게시글_삭제_하기_성공">1.5.1 게시글 삭제 하기 성공</a></li>
+<li><a href="#_1_5_2_게시글_삭제_권한_없음">1.5.2 게시글 삭제 권한 없음</a></li>
 </ul>
 </li>
-<li><a href="#_6_게시글_좋아요">6. 게시글 좋아요</a>
+<li><a href="#_1_6_게시글_좋아요">1.6. 게시글 좋아요</a>
 <ul class="sectlevel2">
-<li><a href="#_6_1_게시글_좋아요_성공">6.1 게시글 좋아요 성공</a></li>
+<li><a href="#_1_6_1_게시글_좋아요_성공">1.6.1 게시글 좋아요 성공</a></li>
+<li><a href="#_1_6_2_본인_글에_좋아요하는_경우">1.6.2 본인 글에 좋아요하는 경우</a></li>
 </ul>
 </li>
 </ul>
@@ -486,12 +490,12 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 </div>
 <div id="content">
-<h1 id="resources-post" class="sect0"><a class="link" href="#resources-post">게시글</a></h1>
+<h1 id="resources-post" class="sect0"><a class="link" href="#resources-post">1. 게시글</a></h1>
 <div class="sect1">
-<h2 id="_1_게시글_상세_보기"><a class="link" href="#_1_게시글_상세_보기">1. 게시글 상세 보기</a></h2>
+<h2 id="_1_1_게시글_상세_보기"><a class="link" href="#_1_1_게시글_상세_보기">1.1. 게시글 상세 보기</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_1_1_게시글_상세_보기_성공"><a class="link" href="#_1_1_게시글_상세_보기_성공">1.1 게시글 상세 보기 성공</a></h3>
+<h3 id="_1_1_1_게시글_상세_보기_성공"><a class="link" href="#_1_1_1_게시글_상세_보기_성공">1.1.1 게시글 상세 보기 성공</a></h3>
 <div class="sect3">
 <h4 id="_http_request"><a class="link" href="#_http_request">HTTP request</a></h4>
 <div class="listingblock">
@@ -509,7 +513,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 289
+Content-Length: 291
 
 {
   "id" : 1,
@@ -522,8 +526,38 @@ Content-Length: 289
   "likeCount" : 0,
   "isOwner" : false,
   "isLike" : false,
-  "createDate" : "2023-01-23T21:26:45.814406",
-  "modifyDate" : "2023-01-23T21:26:45.814406"
+  "createDate" : "2023-01-26T00:08:44.6338589",
+  "modifyDate" : "2023-01-26T00:08:44.6338589"
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_1_1_2_존재하지_않는_게시글인_경우"><a class="link" href="#_1_1_2_존재하지_않는_게시글인_경우">1.1.2 존재하지 않는 게시글인 경우</a></h3>
+<div class="sect3">
+<h4 id="_http_request_2"><a class="link" href="#_http_request_2">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /boards/1/posts/99 HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_http_response_2"><a class="link" href="#_http_response_2">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 404 Not Found
+Content-Type: application/json
+Content-Length: 98
+
+{
+  "message" : "존재하지 않는 게시글입니다.",
+  "errors" : [ ],
+  "code" : 3001
 }</code></pre>
 </div>
 </div>
@@ -532,12 +566,12 @@ Content-Length: 289
 </div>
 </div>
 <div class="sect1">
-<h2 id="_2_게시글_목록_보기"><a class="link" href="#_2_게시글_목록_보기">2. 게시글 목록 보기</a></h2>
+<h2 id="_1_2_게시글_목록_보기"><a class="link" href="#_1_2_게시글_목록_보기">1.2. 게시글 목록 보기</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_2_1_게시글_목록_보기_성공"><a class="link" href="#_2_1_게시글_목록_보기_성공">2.1 게시글 목록 보기 성공</a></h3>
+<h3 id="_1_2_1_게시글_목록_보기_성공"><a class="link" href="#_1_2_1_게시글_목록_보기_성공">1.2.1 게시글 목록 보기 성공</a></h3>
 <div class="sect3">
-<h4 id="_http_request_2"><a class="link" href="#_http_request_2">HTTP request</a></h4>
+<h4 id="_http_request_3"><a class="link" href="#_http_request_3">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /boards/1/posts?page=0&amp;size=20 HTTP/1.1
@@ -548,7 +582,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_2"><a class="link" href="#_http_response_2">HTTP response</a></h4>
+<h4 id="_http_response_3"><a class="link" href="#_http_response_3">HTTP response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -566,8 +600,8 @@ Content-Length: 632
     "viewCount" : 0,
     "likeCount" : 0,
     "commentCount" : 0,
-    "createDate" : "2023-01-23T21:26:46.6512663",
-    "modifyDate" : "2023-01-23T21:26:46.6512663"
+    "createDate" : "2023-01-26T00:08:45.6327219",
+    "modifyDate" : "2023-01-26T00:08:45.6327219"
   }, {
     "id" : 1,
     "member" : {
@@ -578,8 +612,8 @@ Content-Length: 632
     "viewCount" : 0,
     "likeCount" : 0,
     "commentCount" : 0,
-    "createDate" : "2023-01-23T21:26:46.6512663",
-    "modifyDate" : "2023-01-23T21:26:46.6522662"
+    "createDate" : "2023-01-26T00:08:45.6327219",
+    "modifyDate" : "2023-01-26T00:08:45.6327219"
   } ],
   "isLast" : true
 }</code></pre>
@@ -590,12 +624,12 @@ Content-Length: 632
 </div>
 </div>
 <div class="sect1">
-<h2 id="_3_게시글_생성_하기"><a class="link" href="#_3_게시글_생성_하기">3. 게시글 생성 하기</a></h2>
+<h2 id="_1_3_게시글_생성_하기"><a class="link" href="#_1_3_게시글_생성_하기">1.3. 게시글 생성 하기</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_3_1_게시글_생성_하기_성공"><a class="link" href="#_3_1_게시글_생성_하기_성공">3.1 게시글 생성 하기 성공</a></h3>
+<h3 id="_1_3_게시글_생성_하기_성공"><a class="link" href="#_1_3_게시글_생성_하기_성공">1.3. 게시글 생성 하기 성공</a></h3>
 <div class="sect3">
-<h4 id="_http_request_3"><a class="link" href="#_http_request_3">HTTP request</a></h4>
+<h4 id="_http_request_4"><a class="link" href="#_http_request_4">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /boards/1/posts HTTP/1.1
@@ -611,7 +645,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_3"><a class="link" href="#_http_response_3">HTTP response</a></h4>
+<h4 id="_http_response_4"><a class="link" href="#_http_response_4">HTTP response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 201 Created
@@ -623,12 +657,12 @@ Location: /boards/1/posts/1</code></pre>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_4_게시글_수정_하기"><a class="link" href="#_4_게시글_수정_하기">4. 게시글 수정 하기</a></h2>
+<h2 id="_1_4_게시글_수정_하기"><a class="link" href="#_1_4_게시글_수정_하기">1.4. 게시글 수정 하기</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_4_1_게시글_수정_하기_성공"><a class="link" href="#_4_1_게시글_수정_하기_성공">4.1 게시글 수정 하기 성공</a></h3>
+<h3 id="_1_4_1_게시글_수정_하기_성공"><a class="link" href="#_1_4_1_게시글_수정_하기_성공">1.4.1 게시글 수정 하기 성공</a></h3>
 <div class="sect3">
-<h4 id="_http_request_4"><a class="link" href="#_http_request_4">HTTP request</a></h4>
+<h4 id="_http_request_5"><a class="link" href="#_http_request_5">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /boards/1/posts/1 HTTP/1.1
@@ -644,7 +678,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_4"><a class="link" href="#_http_response_4">HTTP response</a></h4>
+<h4 id="_http_response_5"><a class="link" href="#_http_response_5">HTTP response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK</code></pre>
@@ -652,15 +686,50 @@ Host: localhost:8080
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_1_4_2_게시글_수정_권한_없음"><a class="link" href="#_1_4_2_게시글_수정_권한_없음">1.4.2 게시글 수정 권한 없음</a></h3>
+<div class="sect3">
+<h4 id="_http_request_6"><a class="link" href="#_http_request_6">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /boards/1/posts/1 HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+Content-Length: 38
+Host: localhost:8080
+
+{
+  "content" : "수정할 내용"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_http_response_6"><a class="link" href="#_http_response_6">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Content-Type: application/json
+Content-Length: 108
+
+{
+  "message" : "해당 게시글에 대한 권한이 없습니다",
+  "errors" : [ ],
+  "code" : 3002
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_5_게시글_삭제_하기"><a class="link" href="#_5_게시글_삭제_하기">5. 게시글 삭제 하기</a></h2>
+<h2 id="_1_5_게시글_삭제_하기"><a class="link" href="#_1_5_게시글_삭제_하기">1.5. 게시글 삭제 하기</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_5_1_게시글_삭제_하기_성공"><a class="link" href="#_5_1_게시글_삭제_하기_성공">5.1 게시글 삭제 하기 성공</a></h3>
+<h3 id="_1_5_1_게시글_삭제_하기_성공"><a class="link" href="#_1_5_1_게시글_삭제_하기_성공">1.5.1 게시글 삭제 하기 성공</a></h3>
 <div class="sect3">
-<h4 id="_http_request_5"><a class="link" href="#_http_request_5">HTTP request</a></h4>
+<h4 id="_http_request_7"><a class="link" href="#_http_request_7">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /boards/1/posts/1 HTTP/1.1
@@ -671,7 +740,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_5"><a class="link" href="#_http_response_5">HTTP response</a></h4>
+<h4 id="_http_response_7"><a class="link" href="#_http_response_7">HTTP response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 204 No Content</code></pre>
@@ -679,15 +748,45 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_1_5_2_게시글_삭제_권한_없음"><a class="link" href="#_1_5_2_게시글_삭제_권한_없음">1.5.2 게시글 삭제 권한 없음</a></h3>
+<div class="sect3">
+<h4 id="_http_request_8"><a class="link" href="#_http_request_8">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /boards/1/posts/1 HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_http_response_8"><a class="link" href="#_http_response_8">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Content-Type: application/json
+Content-Length: 108
+
+{
+  "message" : "해당 게시글에 대한 권한이 없습니다",
+  "errors" : [ ],
+  "code" : 3002
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_6_게시글_좋아요"><a class="link" href="#_6_게시글_좋아요">6. 게시글 좋아요</a></h2>
+<h2 id="_1_6_게시글_좋아요"><a class="link" href="#_1_6_게시글_좋아요">1.6. 게시글 좋아요</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_6_1_게시글_좋아요_성공"><a class="link" href="#_6_1_게시글_좋아요_성공">6.1 게시글 좋아요 성공</a></h3>
+<h3 id="_1_6_1_게시글_좋아요_성공"><a class="link" href="#_1_6_1_게시글_좋아요_성공">1.6.1 게시글 좋아요 성공</a></h3>
 <div class="sect3">
-<h4 id="_http_request_6"><a class="link" href="#_http_request_6">HTTP request</a></h4>
+<h4 id="_http_request_9"><a class="link" href="#_http_request_9">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PUT /posts/1/like HTTP/1.1
@@ -698,7 +797,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_6"><a class="link" href="#_http_response_6">HTTP response</a></h4>
+<h4 id="_http_response_9"><a class="link" href="#_http_response_9">HTTP response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -713,13 +812,43 @@ Content-Length: 43
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_1_6_2_본인_글에_좋아요하는_경우"><a class="link" href="#_1_6_2_본인_글에_좋아요하는_경우">1.6.2 본인 글에 좋아요하는 경우</a></h3>
+<div class="sect3">
+<h4 id="_http_request_10"><a class="link" href="#_http_request_10">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PUT /posts/1/like HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_http_response_10"><a class="link" href="#_http_response_10">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 403 Forbidden
+Content-Type: application/json
+Content-Length: 113
+
+{
+  "message" : "본인 글에는 좋아요를 누를 수 없습니다.",
+  "errors" : [ ],
+  "code" : 4001
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-01-23 21:00:36 +0900
+Last updated 2023-01-25 22:59:17 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/com/masil/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/masil/domain/post/service/PostServiceTest.java
@@ -6,6 +6,8 @@ import com.masil.domain.member.repository.MemberRepository;
 import com.masil.domain.post.dto.*;
 import com.masil.domain.post.entity.Post;
 import com.masil.domain.post.entity.State;
+import com.masil.domain.post.exception.PostAccessDeniedException;
+import com.masil.domain.post.exception.PostNotFoundException;
 import com.masil.domain.post.repository.PostRepository;
 import com.masil.global.error.exception.BusinessException;
 import org.junit.jupiter.api.BeforeEach;
@@ -81,6 +83,16 @@ public class PostServiceTest extends ServiceTest {
         assertThat(postDetailResponse.getIsOwner()).isEqualTo(false);
         assertThat(postDetailResponse.getIsLike()).isEqualTo(false);
     }
+
+    @DisplayName("존재하지 않는 게시글일 경우 예외가 발생한다")
+    @Test
+    void findPost_notFound() {
+
+        // when, then
+        assertThatThrownBy(() -> postService.findDetailPost(100L, 2L))
+                .isInstanceOf(PostNotFoundException.class);
+    }
+
     @DisplayName("본인의 상세 게시글인 경우")
     @Test
     void findPost_isOwner() {
@@ -172,7 +184,7 @@ public class PostServiceTest extends ServiceTest {
 
         // when, then
         assertThatThrownBy(() -> postService.modifyPost(post.getId(), postModifyRequest, 2L))
-                .isInstanceOf(BusinessException.class);
+                .isInstanceOf(PostAccessDeniedException.class);
     }
 
     @DisplayName("게시글 삭제 성공")
@@ -200,6 +212,6 @@ public class PostServiceTest extends ServiceTest {
 
         // when, then
         assertThatThrownBy(() -> postService.deletePost(post.getId(), 2L))
-                .isInstanceOf(BusinessException.class);
+                .isInstanceOf(PostAccessDeniedException.class);
     }
 }

--- a/src/test/java/com/masil/domain/postlike/controller/PostLikeControllerTest.java
+++ b/src/test/java/com/masil/domain/postlike/controller/PostLikeControllerTest.java
@@ -2,6 +2,7 @@ package com.masil.domain.postlike.controller;
 
 import com.masil.common.annotation.ControllerMockApiTest;
 import com.masil.domain.postlike.dto.PostLikeResponse;
+import com.masil.domain.postlike.exception.SelfPostLikeException;
 import com.masil.domain.postlike.service.PostLikeService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,30 @@ class PostLikeControllerTest extends ControllerMockApiTest {
                         responseFields(
                                 fieldWithPath("likeCount").description("좋아요 개수"),
                                 fieldWithPath("isLike").description("좋아요 여부")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("본인 글에 좋아요를 누를 경우 예외가 발생한다.")
+    void likePost_selfLike() throws Exception {
+        // given
+        given(postLikeService.toggleLikePost(any(), any()))
+                .willThrow(new SelfPostLikeException());
+
+        // when
+        ResultActions resultActions = requestLikePost("/posts/1/like");
+
+        // then
+        resultActions
+                .andExpect(status().isForbidden())
+                .andDo(document("post/like/selfLike",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("message").description("에러 메세지"),
+                                fieldWithPath("errors").description("에러 종류"),
+                                fieldWithPath("code").description("코드")
                         )
                 ));
     }

--- a/src/test/java/com/masil/domain/postlike/service/PostLikeServiceTest.java
+++ b/src/test/java/com/masil/domain/postlike/service/PostLikeServiceTest.java
@@ -5,10 +5,12 @@ import com.masil.domain.member.entity.Member;
 import com.masil.domain.member.repository.MemberRepository;
 import com.masil.domain.post.dto.PostDetailResponse;
 import com.masil.domain.post.entity.Post;
+import com.masil.domain.post.exception.PostAccessDeniedException;
 import com.masil.domain.post.repository.PostRepository;
 import com.masil.domain.post.service.PostService;
 import com.masil.domain.postlike.dto.PostLikeResponse;
 import com.masil.domain.postlike.entity.PostLike;
+import com.masil.domain.postlike.exception.SelfPostLikeException;
 import com.masil.domain.postlike.repository.PostLikeRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Commit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 class PostLikeServiceTest extends ServiceTest {
@@ -104,10 +107,12 @@ class PostLikeServiceTest extends ServiceTest {
     @Test
     void toggleLikePost_isOwner() {
         // then
+        Post post = postRepository.findById(1L).get();
+        Member member = memberRepository.findById(1L).get();
 
-        // when
-
-        // then
+        // then, when
+        assertThatThrownBy(() -> postLikeService.toggleLikePost(post.getId(), member.getId()))
+                .isInstanceOf(SelfPostLikeException.class);
     }
 
 }


### PR DESCRIPTION
# 작업 내용
- ErrorCode, ErrorResponse 컬럼 일부 수정했습니다.

- 예외 생성과 관련하여
도메인 전체적으로 쓰일 것 같은 예외는 global에 BusinessException 상속 받아서 하나 만드시면 될 거 같습니다.
저 같은 경우에는 권한 관련으로 NoAuthenticationException 하나 만들어 주었습니다.

- post에 바뀐 예외로 수정하였습니다.
- 예외처리에 대한 테스크 코드 작성하였습니다.
- 일단 전체적으로 예외 로직을 수정해봤는데 비효율적인 부분이 있는 거 같습니다.
- 좀 더 좋은 방안이 있으시면 말씀해주세요.

Closes 이슈번호
#25 