### PR TITLE
feat : 카테고리 추가

### DIFF
--- a/src/main/java/com/masil/domain/board/entity/Board.java
+++ b/src/main/java/com/masil/domain/board/entity/Board.java
@@ -1,0 +1,22 @@
+package com.masil.domain.board.entity;
+
+import com.masil.global.common.entity.BaseEntity;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@SuperBuilder
+@RequiredArgsConstructor
+public class Board extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String name;
+}

--- a/src/main/java/com/masil/domain/board/entity/Board.java
+++ b/src/main/java/com/masil/domain/board/entity/Board.java
@@ -1,6 +1,7 @@
 package com.masil.domain.board.entity;
 
 import com.masil.global.common.entity.BaseEntity;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -19,4 +20,10 @@ public class Board extends BaseEntity {
 
     @Column(unique = true, nullable = false)
     private String name;
+
+    @Builder
+    private Board(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
 }

--- a/src/main/java/com/masil/domain/board/exception/BoardNotFoundException.java
+++ b/src/main/java/com/masil/domain/board/exception/BoardNotFoundException.java
@@ -1,0 +1,10 @@
+package com.masil.domain.board.exception;
+
+import com.masil.global.error.exception.EntityNotFoundException;
+import com.masil.global.error.exception.ErrorCode;
+
+public class BoardNotFoundException extends EntityNotFoundException {
+    public BoardNotFoundException() {
+        super(ErrorCode.BOARD_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/masil/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/masil/domain/board/repository/BoardRepository.java
@@ -1,0 +1,7 @@
+package com.masil.domain.board.repository;
+
+import com.masil.domain.board.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/src/main/java/com/masil/domain/post/controller/PostController.java
+++ b/src/main/java/com/masil/domain/post/controller/PostController.java
@@ -64,9 +64,8 @@ public class PostController {
 
     // 수정
     @PreAuthorize("isAuthenticated()")
-    @PatchMapping("/boards/{boardId}/posts/{postId}")
-    public ResponseEntity<Void> modifyPost(@PathVariable Long boardId,
-                                           @PathVariable Long postId,
+    @PatchMapping("/posts/{postId}")
+    public ResponseEntity<Void> modifyPost(@PathVariable Long postId,
                                            @Valid @RequestBody PostModifyRequest postModifyRequest,
                                            @LoginUser CurrentMember currentMember) {
         log.info("게시글 수정 시작");
@@ -77,9 +76,8 @@ public class PostController {
 
     // 삭제
     @PreAuthorize("isAuthenticated()")
-    @DeleteMapping("/boards/{boardId}/posts/{postId}")
-    public ResponseEntity<Void> deletePost(@PathVariable Long boardId,
-                                           @PathVariable Long postId,
+    @DeleteMapping("/posts/{postId}")
+    public ResponseEntity<Void> deletePost(@PathVariable Long postId,
                                            @LoginUser CurrentMember currentMember) {
         log.info("게시글 삭제 시작");
 

--- a/src/main/java/com/masil/domain/post/controller/PostController.java
+++ b/src/main/java/com/masil/domain/post/controller/PostController.java
@@ -24,16 +24,15 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/boards")
+@RequestMapping()
 @Slf4j
 public class PostController {
 
     private final PostService postService;
 
     // 상세 조회
-    @GetMapping("/{boardId}/posts/{postId}")
-    public ResponseEntity<PostDetailResponse> findDetailPost(@PathVariable Long boardId,
-                                                             @PathVariable Long postId,
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<PostDetailResponse> findDetailPost(@PathVariable Long postId,
                                                              @LoginUser CurrentMember currentMember) {
         log.info("게시글 상세 조회 시작");
 
@@ -43,7 +42,7 @@ public class PostController {
     }
 
     // 목록 조회
-    @GetMapping("/{boardId}/posts")
+    @GetMapping("/boards/{boardId}/posts")
     public ResponseEntity<PostsResponse> findAllPost(@PathVariable Long boardId,
                                                      @PageableDefault(sort = "createDate", direction = DESC) Pageable pageable) {
         log.info("게시글 목록 조회 시작");
@@ -54,19 +53,18 @@ public class PostController {
 
     // 생성
     @PreAuthorize("isAuthenticated()")
-    @PostMapping("/{boardId}/posts")
-    public ResponseEntity<Void> createPost(@PathVariable Long boardId,
-                                           @Valid @RequestBody PostCreateRequest postCreateRequest,
+    @PostMapping("/posts")
+    public ResponseEntity<Void> createPost(@Valid @RequestBody PostCreateRequest postCreateRequest,
                                            @LoginUser CurrentMember currentMember) {
         log.info("게시글 생성 시작");
 
         Long postId = postService.createPost(postCreateRequest, currentMember.getId());
-        return ResponseEntity.created(URI.create("/boards/" + boardId + "/posts/" + postId)).build();
+        return ResponseEntity.created(URI.create("/posts/" + postId)).build();
     }
 
     // 수정
     @PreAuthorize("isAuthenticated()")
-    @PatchMapping("/{boardId}/posts/{postId}")
+    @PatchMapping("/boards/{boardId}/posts/{postId}")
     public ResponseEntity<Void> modifyPost(@PathVariable Long boardId,
                                            @PathVariable Long postId,
                                            @Valid @RequestBody PostModifyRequest postModifyRequest,
@@ -79,7 +77,7 @@ public class PostController {
 
     // 삭제
     @PreAuthorize("isAuthenticated()")
-    @DeleteMapping("/{boardId}/posts/{postId}")
+    @DeleteMapping("/boards/{boardId}/posts/{postId}")
     public ResponseEntity<Void> deletePost(@PathVariable Long boardId,
                                            @PathVariable Long postId,
                                            @LoginUser CurrentMember currentMember) {

--- a/src/main/java/com/masil/domain/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/masil/domain/post/dto/PostCreateRequest.java
@@ -1,13 +1,14 @@
 package com.masil.domain.post.dto;
 
+import com.masil.domain.board.entity.Board;
 import com.masil.domain.post.entity.Post;
 import com.masil.domain.member.entity.Member;
-import com.masil.domain.post.entity.State;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 @Getter
 @NoArgsConstructor
@@ -16,16 +17,20 @@ public class PostCreateRequest {
     @NotBlank(message = "본문이 없습니다.")
     private String content;
 
+    @NotNull(message = "카테고리를 선택해주세요.")
+    private Long boardId;
+
     @Builder
-    public PostCreateRequest(String content){
+    public PostCreateRequest(String content, Long boardId){
         this.content = content;
+        this.boardId = boardId;
     }
 
-    public Post toEntity(Member member){
+    public Post toEntity(Member member, Board board){
         return Post.builder()
                 .member(member)
                 .content(content)
-                .state(State.NORMAL)
+                .board(board)
                 .build();
     }
 }

--- a/src/main/java/com/masil/domain/post/dto/PostModifyRequest.java
+++ b/src/main/java/com/masil/domain/post/dto/PostModifyRequest.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 @Getter
 @NoArgsConstructor
@@ -13,8 +14,12 @@ public class PostModifyRequest {
     @NotBlank(message = "본문이 없습니다.")
     private String content;
 
+    @NotNull(message = "카테고리를 선택해주세요.")
+    private Long boardId;
+
     @Builder
-    public PostModifyRequest(String content){
+    public PostModifyRequest(String content, Long boardId){
         this.content = content;
+        this.boardId = boardId;
     }
 }

--- a/src/main/java/com/masil/domain/post/entity/Post.java
+++ b/src/main/java/com/masil/domain/post/entity/Post.java
@@ -33,6 +33,7 @@ public class Post extends BaseEntity {
     @Column(columnDefinition = "integer default 0", nullable = false)
     private int likeCount;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     private State state = State.NORMAL;
 
@@ -49,10 +50,11 @@ public class Post extends BaseEntity {
     private List<Comment> comments = new ArrayList<>();
 
     @Builder
-    private Post(String content, Member member, State state) {
+    private Post(String content, Member member, State state, Board board) {
         this.content = content;
         this.member = member;
         this.state = state;
+        this.board = board;
     }
     
     public void updateContent(String content){

--- a/src/main/java/com/masil/domain/post/entity/Post.java
+++ b/src/main/java/com/masil/domain/post/entity/Post.java
@@ -57,8 +57,9 @@ public class Post extends BaseEntity {
         this.board = board;
     }
     
-    public void updateContent(String content){
+    public void updateContentAndBoard(String content, Board board){
         this.content = content;
+        this.board = board;
     }
 
     public void tempDelete() {

--- a/src/main/java/com/masil/domain/post/entity/Post.java
+++ b/src/main/java/com/masil/domain/post/entity/Post.java
@@ -1,5 +1,6 @@
 package com.masil.domain.post.entity;
 
+import com.masil.domain.board.entity.Board;
 import com.masil.domain.comment.entity.Comment;
 import com.masil.domain.member.entity.Member;
 import com.masil.global.common.entity.BaseEntity;
@@ -38,6 +39,10 @@ public class Post extends BaseEntity {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
 
     @Builder.Default
     @OneToMany(mappedBy = "post")

--- a/src/main/java/com/masil/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/masil/domain/post/repository/PostRepository.java
@@ -1,9 +1,13 @@
 package com.masil.domain.post.repository;
 
 import com.masil.domain.post.entity.Post;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Slice<Post> findAllByBoardId(Long boardId, Pageable pageable);
 }

--- a/src/main/java/com/masil/domain/post/service/PostService.java
+++ b/src/main/java/com/masil/domain/post/service/PostService.java
@@ -1,5 +1,8 @@
 package com.masil.domain.post.service;
 
+import com.masil.domain.board.entity.Board;
+import com.masil.domain.board.exception.BoardNotFoundException;
+import com.masil.domain.board.repository.BoardRepository;
 import com.masil.domain.member.exception.MemberNotFoundException;
 import com.masil.domain.post.dto.*;
 
@@ -27,6 +30,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final PostLikeRepository postLikeRepository;
+    private final BoardRepository boardRepository;
 
     public PostDetailResponse findDetailPost(Long postId, Long memberId) { // memberId 임시값
         Post post = findPostById(postId);
@@ -42,14 +46,15 @@ public class PostService {
     }
 
     public PostsResponse findAllPost(Long boardId, Pageable pageable) {
-        Slice<Post> posts = postRepository.findAll(pageable);
+        Slice<Post> posts = postRepository.findAllByBoardId(boardId, pageable);
         return PostsResponse.ofPosts(posts);
     }
 
     @Transactional
     public Long createPost(PostCreateRequest postCreateRequest, Long memberId){
         Member member = findMemberById(memberId);
-        Post post = postCreateRequest.toEntity(member);
+        Board board = findBoardById(postCreateRequest.getBoardId());
+        Post post = postCreateRequest.toEntity(member, board);
         return postRepository.save(post).getId();
     }
 
@@ -87,5 +92,9 @@ public class PostService {
     private Member findMemberById(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
+    }
+    private Board findBoardById(Long boardId) {
+        return boardRepository.findById(boardId)
+                .orElseThrow(BoardNotFoundException::new);
     }
 }

--- a/src/main/java/com/masil/domain/post/service/PostService.java
+++ b/src/main/java/com/masil/domain/post/service/PostService.java
@@ -62,10 +62,11 @@ public class PostService {
     public void modifyPost(Long postId, PostModifyRequest postModifyRequest, Long memberId){
         Post post = findPostById(postId);
         findMemberById(memberId);
+        Board board = findBoardById(postModifyRequest.getBoardId());
 
         validateOwner(memberId, post);
 
-        post.updateContent(postModifyRequest.getContent());
+        post.updateContentAndBoard(postModifyRequest.getContent(), board);
     }
 
     @Transactional

--- a/src/main/java/com/masil/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/masil/global/error/exception/ErrorCode.java
@@ -24,9 +24,10 @@ public enum ErrorCode {
     POST_NOT_SELF_LIKE(FORBIDDEN, 4001, "본인 글에는 좋아요를 누를 수 없습니다."),
 
     // commentLike
-    COMMENT_NOT_SELF_LIKE(FORBIDDEN, 4001, "본인 댓글에는 좋아요를 누를 수 없습니다.")
+    COMMENT_NOT_SELF_LIKE(FORBIDDEN, 4001, "본인 댓글에는 좋아요를 누를 수 없습니다."),
 
-    ;
+    // board
+    BOARD_NOT_FOUND(NOT_FOUND, 9001, "존재하지 않는 카테고리입니다.");
 
     private HttpStatus status;
     private final int code;

--- a/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
@@ -71,17 +71,18 @@ public class PostControllerTest extends ControllerMockApiTest {
         given(postService.createPost(any(), any())).willReturn(1L);
 
         // when
-        ResultActions resultActions = requestCreatePost("/boards/1/posts", postCreateRequest);
+        ResultActions resultActions = requestCreatePost("/posts", postCreateRequest);
 
         // then
         resultActions
                 .andExpect(status().isCreated())
-                .andExpect(header().string("Location", "/boards/1/posts/1"))
+                .andExpect(header().string("Location", "/posts/1"))
                 .andDo(document("post/create",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestFields(
-                                fieldWithPath("content").description("내용")
+                                fieldWithPath("content").description("내용"),
+                                fieldWithPath("boardId").description("카테고리Id")
                         )
                 ));
     }
@@ -94,7 +95,7 @@ public class PostControllerTest extends ControllerMockApiTest {
         given(postService.findDetailPost(any(), any())).willReturn(POST_RESPONSE_1);
 
         // when
-        ResultActions resultActions = requestFindPost("/boards/1/posts/1");
+        ResultActions resultActions = requestFindPost("/posts/1");
 
         // then
         resultActions
@@ -124,7 +125,7 @@ public class PostControllerTest extends ControllerMockApiTest {
         given(postService.findDetailPost(any(), any())).willThrow(new PostNotFoundException());
 
         // when
-        ResultActions resultActions = requestFindPost("/boards/1/posts/99");
+        ResultActions resultActions = requestFindPost("/posts/99");
 
         // then
         resultActions

--- a/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
@@ -205,7 +205,7 @@ public class PostControllerTest extends ControllerMockApiTest {
         willDoNothing().given(postService).modifyPost(any(),any(),any());
 
         // when
-        ResultActions resultActions = requestModifyPost("/boards/1/posts/1" ,postModifyRequest);
+        ResultActions resultActions = requestModifyPost("/posts/1" ,postModifyRequest);
 
         // then
         resultActions
@@ -214,7 +214,8 @@ public class PostControllerTest extends ControllerMockApiTest {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestFields(
-                                fieldWithPath("content").description("수정할 내용")
+                                fieldWithPath("content").description("수정할 내용"),
+                                fieldWithPath("boardId").description("카테고리Id")
                         )
                 ));
     }
@@ -228,7 +229,7 @@ public class PostControllerTest extends ControllerMockApiTest {
         willThrow(new PostAccessDeniedException()).given(postService).modifyPost(any(),any(),any());
 
         // when
-        ResultActions resultActions = requestModifyPost("/boards/1/posts/1" ,postModifyRequest);
+        ResultActions resultActions = requestModifyPost("/posts/1" ,postModifyRequest);
 
         // then
         resultActions
@@ -250,7 +251,7 @@ public class PostControllerTest extends ControllerMockApiTest {
 
         willDoNothing().given(postService).deletePost(any(), any());
         // when
-        ResultActions resultActions = requestDeletePost("/boards/1/posts/1");
+        ResultActions resultActions = requestDeletePost("/posts/1");
 
         // then
         resultActions
@@ -269,7 +270,7 @@ public class PostControllerTest extends ControllerMockApiTest {
         willThrow(new PostAccessDeniedException()).given(postService).deletePost(any(), any());
 
         // when
-        ResultActions resultActions = requestDeletePost("/boards/1/posts/1");
+        ResultActions resultActions = requestDeletePost("/posts/1");
 
         // then
         resultActions

--- a/src/test/java/com/masil/domain/post/dto/PostCreateRequestBuilder.java
+++ b/src/test/java/com/masil/domain/post/dto/PostCreateRequestBuilder.java
@@ -3,12 +3,16 @@ package com.masil.domain.post.dto;
 
 public class PostCreateRequestBuilder {
 
+    public static PostCreateRequest build(String content, Long boardId) {
+        return new PostCreateRequest(content, boardId);
+    }
+
     public static PostCreateRequest build(String content) {
-        return new PostCreateRequest(content);
+        return new PostCreateRequest(content, 1L);
     }
 
     public static PostCreateRequest build() {
-        return new PostCreateRequest("생성될 내용");
+        return new PostCreateRequest("생성될 내용", 1L);
     }
 
 }

--- a/src/test/java/com/masil/domain/post/dto/PostModifyRequestBuilder.java
+++ b/src/test/java/com/masil/domain/post/dto/PostModifyRequestBuilder.java
@@ -1,11 +1,15 @@
 package com.masil.domain.post.dto;
 
 public class PostModifyRequestBuilder {
+
+    public static PostModifyRequest build(String content, Long boardId) {
+        return new PostModifyRequest(content, boardId);
+    }
     public static PostModifyRequest build(String content) {
-        return new PostModifyRequest(content);
+        return new PostModifyRequest(content, 1L);
     }
 
     public static PostModifyRequest build() {
-        return new PostModifyRequest("수정할 내용");
+        return new PostModifyRequest("수정할 내용", 1L);
     }
 }

--- a/src/test/java/com/masil/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/masil/domain/post/service/PostServiceTest.java
@@ -176,7 +176,7 @@ public class PostServiceTest extends ServiceTest {
         String content = "수정 후 내용";
         Post beforePost = postRepository.findById(1L).get();
 
-        PostModifyRequest postModifyRequest = new PostModifyRequest(content);
+        PostModifyRequest postModifyRequest = PostModifyRequestBuilder.build(content);
 
         // when
         postService.modifyPost(beforePost.getId(), postModifyRequest, member.getId());
@@ -193,7 +193,7 @@ public class PostServiceTest extends ServiceTest {
         String content = "수정 후 내용";
         Post post = postRepository.findById(1L).get();
 
-        PostModifyRequest postModifyRequest = new PostModifyRequest(content);
+        PostModifyRequest postModifyRequest = PostModifyRequestBuilder.build(content);
 
         // when, then
         assertThatThrownBy(() -> postService.modifyPost(post.getId(), postModifyRequest, 2L))


### PR DESCRIPTION
# 작업 내용
말씀해주신 정적으로 처리하는 방법은 나중에 알아본 뒤에 적용해보겠습니다.
일단은 연관관계 맺도록 구현했습니다.

post 요청 url이 변했습니다.
boardId값이 굳이 필요없는 부분은 뺐습니다.
생성, 수정의 경우 boardId를 body값으로 받도록 변경하였습니다.


Closes 이슈번호
#38 