### PR TITLE
feat : post 주소관련 로직 추가

### DIFF
--- a/src/main/java/com/masil/domain/address/dto/response/AddressSearchResponse.java
+++ b/src/main/java/com/masil/domain/address/dto/response/AddressSearchResponse.java
@@ -8,15 +8,15 @@ import lombok.Getter;
 @Getter
 public class AddressSearchResponse {
 
-    private Long emdId;
-    private Long sggId;
-    private Long sidoId;
+    private Integer emdId;
+    private Integer sggId;
+    private Integer sidoId;
     private String sidoName;
     private String sggName;
     private String emdName;
 
     @Builder
-    public AddressSearchResponse(Long emdId, Long sggId, Long sidoId, String sidoName, String sggName, String emdName) {
+    public AddressSearchResponse(Integer emdId, Integer sggId, Integer sidoId, String sidoName, String sggName, String emdName) {
         this.emdId = emdId;
         this.sggId = sggId;
         this.sidoId = sidoId;

--- a/src/main/java/com/masil/domain/address/entity/EmdAddress.java
+++ b/src/main/java/com/masil/domain/address/entity/EmdAddress.java
@@ -11,7 +11,7 @@ public class EmdAddress {
 
     @Id
     @Column(name = "emd_address_id")
-    private Long id;
+    private Integer id;
 
     @Column(nullable = false, length = 20)
     private String emdName;

--- a/src/main/java/com/masil/domain/address/entity/SggAddress.java
+++ b/src/main/java/com/masil/domain/address/entity/SggAddress.java
@@ -11,7 +11,7 @@ public class SggAddress {
 
     @Id
     @Column(name = "sgg_id")
-    private Long id;
+    private Integer id;
 
     @Column(nullable = false, length = 20)
     private String sggName;

--- a/src/main/java/com/masil/domain/address/entity/SidoAddress.java
+++ b/src/main/java/com/masil/domain/address/entity/SidoAddress.java
@@ -14,7 +14,7 @@ public class SidoAddress {
 
     @Id
     @Column(name = "sido_id")
-    private Long id;
+    private Integer id;
 
     @Column(length = 20 , nullable = false , unique = true)
     private String sidoName;

--- a/src/main/java/com/masil/domain/address/repository/EmdAddressRepository.java
+++ b/src/main/java/com/masil/domain/address/repository/EmdAddressRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface EmdAddressRepository extends JpaRepository<EmdAddress, Long> {
+public interface EmdAddressRepository extends JpaRepository<EmdAddress, Integer> {
     List<EmdAddress> findByEmdNameContains(String search);
 }

--- a/src/main/java/com/masil/domain/address/repository/SggAddressRepository.java
+++ b/src/main/java/com/masil/domain/address/repository/SggAddressRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface SggAddressRepository extends JpaRepository<SggAddress , Long> {
+public interface SggAddressRepository extends JpaRepository<SggAddress , Integer> {
 
     List<SggAddress> findBySggNameContains(String search);
 

--- a/src/main/java/com/masil/domain/member/entity/Member.java
+++ b/src/main/java/com/masil/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.masil.domain.member.entity;
 
+import com.masil.domain.address.entity.EmdAddress;
 import com.masil.global.auth.entity.Authority;
 import com.masil.global.common.entity.BaseEntity;
 import lombok.AccessLevel;
@@ -45,9 +46,10 @@ public class Member extends BaseEntity {
     @Builder.Default
     private Set<Authority> authorities = new HashSet<>();
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_address_id")
-    private MemberAddress memberAddress;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "emd_address_id")
+    private EmdAddress emdAddress;
+//    private EmdAddress emdAddress;
 
 
     @Builder
@@ -60,5 +62,8 @@ public class Member extends BaseEntity {
         this.authorities = authorities;
     }
 
+    public void updateEmdAddress(EmdAddress emdAddress) {
+        this.emdAddress = emdAddress;
+    }
     // TODO: 2023/01/17 권한 추가 제거
 }

--- a/src/main/java/com/masil/domain/post/controller/PostController.java
+++ b/src/main/java/com/masil/domain/post/controller/PostController.java
@@ -1,9 +1,6 @@
 package com.masil.domain.post.controller;
 
-import com.masil.domain.post.dto.PostCreateRequest;
-import com.masil.domain.post.dto.PostDetailResponse;
-import com.masil.domain.post.dto.PostModifyRequest;
-import com.masil.domain.post.dto.PostsResponse;
+import com.masil.domain.post.dto.*;
 import com.masil.domain.post.service.PostService;
 import com.masil.global.auth.annotaion.LoginUser;
 import com.masil.global.auth.dto.response.CurrentMember;
@@ -41,13 +38,15 @@ public class PostController {
 
     // 목록 조회
     @GetMapping("/boards/{boardId}/posts")
-    public ResponseEntity<PostsResponse> findAllPost(@PathVariable Long boardId,
+    public ResponseEntity<PostsResponse> findPosts(@PathVariable Long boardId,
                                                      @LoginUser CurrentMember currentMember,
+                                                     @RequestParam("rCode") Integer rCode,
                                                      @PageableDefault(sort = "createDate", direction = DESC) Pageable pageable) {
         log.info("게시글 목록 조회 시작");
 
         Long memberId = (currentMember != null) ? currentMember.getId() : null;
-        PostsResponse postsResponse = postService.findAllPost(boardId, memberId, pageable);
+        PostFilterRequest postFilterRequest = new PostFilterRequest(boardId, rCode, pageable);
+        PostsResponse postsResponse = postService.findPosts(postFilterRequest, memberId);
         return ResponseEntity.ok(postsResponse);
     }
 

--- a/src/main/java/com/masil/domain/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/masil/domain/post/dto/PostCreateRequest.java
@@ -31,6 +31,7 @@ public class PostCreateRequest {
                 .member(member)
                 .content(content)
                 .board(board)
+                .emdAddress(member.getEmdAddress())
                 .build();
     }
 }

--- a/src/main/java/com/masil/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/masil/domain/post/dto/PostDetailResponse.java
@@ -14,6 +14,7 @@ public class PostDetailResponse {
     private Long id;
     private MemberResponse member;
     private Long boardId;
+    private String address;
     private String content;
     private int viewCount;
     private int likeCount;
@@ -27,6 +28,7 @@ public class PostDetailResponse {
                 .id(post.getId())
                 .member(MemberResponse.of(post.getMember()))
                 .boardId(post.getBoard().getId())
+                .address(post.getEmdAddress().getEmdName())
                 .content(post.getContent())
                 .viewCount(post.getViewCount())
                 .likeCount(post.getLikeCount())

--- a/src/main/java/com/masil/domain/post/dto/PostFilterRequest.java
+++ b/src/main/java/com/masil/domain/post/dto/PostFilterRequest.java
@@ -7,6 +7,9 @@ import org.springframework.data.domain.Pageable;
 @Getter
 public class PostFilterRequest {
 
+    private static final int SGG_ADDRESS_ID_LENGTH = 5;
+    private static final int EMD_ADDRESS_ID_LENGTH = 8;
+
     private Long boardId;
 
     private Integer rCode;
@@ -20,6 +23,6 @@ public class PostFilterRequest {
     }
 
     public boolean isEmdAddress() {
-        return String.valueOf(rCode).length() > 5;
+        return String.valueOf(rCode).length() > SGG_ADDRESS_ID_LENGTH;
     }
 }

--- a/src/main/java/com/masil/domain/post/dto/PostFilterRequest.java
+++ b/src/main/java/com/masil/domain/post/dto/PostFilterRequest.java
@@ -1,0 +1,25 @@
+package com.masil.domain.post.dto;
+
+import lombok.Getter;
+import org.springframework.data.domain.Pageable;
+
+
+@Getter
+public class PostFilterRequest {
+
+    private Long boardId;
+
+    private Integer rCode;
+
+    private Pageable pageable;
+
+    public PostFilterRequest(Long boardId , Integer rCode, Pageable pageable) {
+        this.boardId = boardId;
+        this.rCode = rCode;
+        this.pageable = pageable;
+    }
+
+    public boolean isEmdAddress() {
+        return String.valueOf(rCode).length() > 5;
+    }
+}

--- a/src/main/java/com/masil/domain/post/dto/PostsElementResponse.java
+++ b/src/main/java/com/masil/domain/post/dto/PostsElementResponse.java
@@ -13,6 +13,7 @@ public class PostsElementResponse {
     private Long id;
     private MemberResponse member;
     private Long boardId;
+    private String address;
     private String content;
     private int viewCount;
     private int likeCount;
@@ -27,6 +28,7 @@ public class PostsElementResponse {
                 .id(post.getId())
                 .member(MemberResponse.of(post.getMember()))
                 .boardId(post.getBoard().getId())
+                .address(post.getEmdAddress().getEmdName())
                 .content(post.getPostPreview())
                 .viewCount(post.getViewCount())
                 .likeCount(post.getLikeCount())

--- a/src/main/java/com/masil/domain/post/entity/Post.java
+++ b/src/main/java/com/masil/domain/post/entity/Post.java
@@ -1,5 +1,6 @@
 package com.masil.domain.post.entity;
 
+import com.masil.domain.address.entity.EmdAddress;
 import com.masil.domain.board.entity.Board;
 import com.masil.domain.comment.entity.Comment;
 import com.masil.domain.member.entity.Member;
@@ -48,22 +49,29 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "board_id")
     private Board board;
 
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "emdAddress_id")
+    private EmdAddress emdAddress;
+
     @Builder.Default
     @OneToMany(mappedBy = "post")
     private List<Comment> comments = new ArrayList<>();
 
+    @Builder.Default
     @Transient
     private Boolean isOwner = false;
 
+    @Builder.Default
     @Transient
     private Boolean isLiked = false;
 
     @Builder
-    private Post(String content, Member member, State state, Board board) {
+    private Post(String content, Member member, State state, Board board , EmdAddress emdAddress) {
         this.content = content;
         this.member = member;
         this.state = state;
         this.board = board;
+        this.emdAddress = emdAddress;
     }
     
     public void updateContentAndBoard(String content, Board board){
@@ -71,10 +79,9 @@ public class Post extends BaseEntity {
         this.board = board;
 
     }
-    public void updateBoolean(Boolean isOwner, Boolean isLiked){
+    public void updatePostPermissions(Boolean isOwner, Boolean isLiked){
         this.isOwner = isOwner;
         this.isLiked = isLiked;
-
     }
 
     public void tempDelete() {

--- a/src/main/java/com/masil/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/masil/domain/post/repository/PostRepository.java
@@ -12,6 +12,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Slice<Post> findAllByBoardId(Long boardId, Pageable pageable);
 
-    Slice<Post> findAllByBoardIdAndState(Long boardId, State normal, Pageable pageable);
+    Slice<Post> findAllByBoardIdAndState(Long boardId, State state, Pageable pageable);
 
+    Slice<Post> findAllByBoardIdAndStateAndEmdAddressId(Long boardId, State state, Integer emdAddressId, Pageable pageable);
+
+    Slice<Post> findAllByBoardIdAndStateAndEmdAddressSggAddressId(Long boardId, State state, Integer sggAddressId, Pageable pageable);
 }

--- a/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
@@ -47,6 +47,7 @@ public class PostControllerTest extends ControllerMockApiTest {
             .id(1L)
             .member(MEMBER_RESPONSE)
             .boardId(1L)
+            .address("옥천동")
             .content("내용1")
             .viewCount(0)
             .likeCount(0)
@@ -104,6 +105,7 @@ public class PostControllerTest extends ControllerMockApiTest {
                                 fieldWithPath("member.id").description("작성자 id"),
                                 fieldWithPath("member.nickname").description("닉네임"),
                                 fieldWithPath("boardId").description("카테고리Id"),
+                                fieldWithPath("address").description("주소"),
                                 fieldWithPath("content").description("내용"),
                                 fieldWithPath("viewCount").description("조회수"),
                                 fieldWithPath("likeCount").description("좋아요 개수"),
@@ -148,6 +150,7 @@ public class PostControllerTest extends ControllerMockApiTest {
                 .id(1L)
                 .member(MEMBER_RESPONSE)
                 .boardId(1L)
+                .address("옥천동")
                 .content("내용")
                 .viewCount(0)
                 .likeCount(0)
@@ -161,10 +164,10 @@ public class PostControllerTest extends ControllerMockApiTest {
 
         PostsResponse postsResponse = new PostsResponse(postsElementResponseList, true);
 
-        given(postService.findAllPost(any(), any(), any())).willReturn(postsResponse);
+        given(postService.findPosts(any(), any())).willReturn(postsResponse);
 
         // when
-        ResultActions resultActions = requestFindAllPost("/boards/1/posts?page=0&size=20");
+        ResultActions resultActions = requestFindAllPost("/boards/1/posts?rCode=11680&page=0&size=8");
 
         // then
         resultActions
@@ -177,6 +180,7 @@ public class PostControllerTest extends ControllerMockApiTest {
                                 fieldWithPath("posts.[].member.id").description("작성자 id"),
                                 fieldWithPath("posts.[].member.nickname").description("닉네임"),
                                 fieldWithPath("posts.[].boardId").description("카테고리Id"),
+                                fieldWithPath("posts.[].address").description("주소"),
                                 fieldWithPath("posts.[].content").description("내용"),
                                 fieldWithPath("posts.[].viewCount").description("조회수"),
                                 fieldWithPath("posts.[].likeCount").description("좋아요 개수"),

--- a/src/test/java/com/masil/domain/post/dto/PostFilterRequestBuilder.java
+++ b/src/test/java/com/masil/domain/post/dto/PostFilterRequestBuilder.java
@@ -1,0 +1,12 @@
+package com.masil.domain.post.dto;
+
+import org.springframework.data.domain.PageRequest;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+public class PostFilterRequestBuilder {
+
+    public static PostFilterRequest build() {
+        return new PostFilterRequest(1L, 11110111, PageRequest.of(0, 8, DESC, "createDate"));
+    }
+}


### PR DESCRIPTION
# 작업 내용
- post 주소관련 로직 추가하였습니다.

- 기존 목록 조회시 pathvariable로 rCode값을 받았는데
boards/1/posts/11110111 로 받으면 post id로 헷갈릴 수 있을 거 같아서 파라미터로 받게 수정하였습니다.

- Memeber 엔티티에 updateEmdAddress 메서드 추가하였습니다.

- 임시로 테스트 코드 성공하게 구현하였습니다. 추후 다른 방식으로 리펙토링할 거 같습니다.

Closes 이슈번호
#50 