### PR TITLE
refactor : auth 이메일 중복 처리 , 재발행 코드 추가 및 코드 정리

### DIFF
--- a/src/main/java/com/masil/domain/member/controller/MemberController.java
+++ b/src/main/java/com/masil/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.masil.domain.member.controller;
 
+import com.masil.domain.member.dto.request.MemberAddressRequest;
 import com.masil.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -25,4 +26,9 @@ public class MemberController {
         memberService.modifyUserToDeleteState();
     }
 
+    @PutMapping("/{memberId}/address")
+    public void modifyMemberAddress(@PathVariable Long memberId,
+                                    @RequestBody MemberAddressRequest request) {
+        memberService.modifyMemberAddress(memberId, request);
+    }
 }

--- a/src/main/java/com/masil/domain/member/dto/request/MemberAddressRequest.java
+++ b/src/main/java/com/masil/domain/member/dto/request/MemberAddressRequest.java
@@ -1,0 +1,15 @@
+package com.masil.domain.member.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberAddressRequest {
+
+    private Integer rCode;
+
+    @Builder
+    public MemberAddressRequest(Integer rCode) {
+        this.rCode = rCode;
+    }
+}

--- a/src/main/java/com/masil/domain/member/dto/request/MemberAddressRequest.java
+++ b/src/main/java/com/masil/domain/member/dto/request/MemberAddressRequest.java
@@ -1,15 +1,18 @@
 package com.masil.domain.member.dto.request;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class MemberAddressRequest {
 
-    private Integer rCode;
+    private Integer emdId;
 
     @Builder
-    public MemberAddressRequest(Integer rCode) {
-        this.rCode = rCode;
+    public MemberAddressRequest(Integer emdId) {
+        this.emdId = emdId;
     }
 }

--- a/src/main/java/com/masil/domain/member/entity/Member.java
+++ b/src/main/java/com/masil/domain/member/entity/Member.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 import java.util.HashSet;
@@ -17,6 +18,7 @@ import java.util.Set;
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
 public class Member extends BaseEntity {
 
     @Id

--- a/src/main/java/com/masil/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/masil/domain/member/repository/MemberRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+    Optional<Object> findByNickname(String nickname);
 }

--- a/src/main/java/com/masil/domain/member/service/MemberService.java
+++ b/src/main/java/com/masil/domain/member/service/MemberService.java
@@ -1,7 +1,13 @@
 package com.masil.domain.member.service;
 
+import com.masil.domain.address.entity.EmdAddress;
+import com.masil.domain.address.repository.EmdAddressRepository;
+import com.masil.domain.member.dto.request.MemberAddressRequest;
+import com.masil.domain.member.entity.Member;
 import com.masil.domain.member.repository.MemberRepository;
 import com.masil.global.auth.repository.AuthorityRepository;
+import com.masil.global.error.exception.EntityNotFoundException;
+import com.masil.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -14,6 +20,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final AuthorityRepository authorityRepository;
+    private final EmdAddressRepository emdAddressRepository;
     private final PasswordEncoder passwordEncoder;
 
     public void getMyUser() {
@@ -24,5 +31,15 @@ public class MemberService {
 
     public void modifyUserToDeleteState() {
 
+    }
+
+    public void modifyMemberAddress(Long memberId, MemberAddressRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        EmdAddress emdAddress = emdAddressRepository.findById(request.getRCode())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        member.updateEmdAddress(emdAddress);
     }
 }

--- a/src/main/java/com/masil/domain/member/service/MemberService.java
+++ b/src/main/java/com/masil/domain/member/service/MemberService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberService {
 
@@ -33,11 +32,12 @@ public class MemberService {
 
     }
 
+    @Transactional
     public void modifyMemberAddress(Long memberId, MemberAddressRequest request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
 
-        EmdAddress emdAddress = emdAddressRepository.findById(request.getRCode())
+        EmdAddress emdAddress = emdAddressRepository.findById(request.getEmdId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
 
         member.updateEmdAddress(emdAddress);

--- a/src/main/java/com/masil/global/auth/controller/AuthController.java
+++ b/src/main/java/com/masil/global/auth/controller/AuthController.java
@@ -25,8 +25,8 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signup")
-    public void signUp(@Valid @RequestBody SignupRequest createRequest) {
-        authService.signUp(createRequest);
+    public void signUp(@Valid @RequestBody SignupRequest signupRequest) {
+        authService.signUp(signupRequest);
     }
     @PostMapping("/login")
     public AuthTokenResponse login(@Valid @RequestBody LoginRequest loginRequest) {

--- a/src/main/java/com/masil/global/auth/controller/AuthController.java
+++ b/src/main/java/com/masil/global/auth/controller/AuthController.java
@@ -9,10 +9,7 @@ import com.masil.global.auth.dto.response.CurrentMember;
 import com.masil.global.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 

--- a/src/main/java/com/masil/global/auth/controller/AuthController.java
+++ b/src/main/java/com/masil/global/auth/controller/AuthController.java
@@ -1,9 +1,11 @@
 package com.masil.global.auth.controller;
 
+import com.masil.global.auth.annotaion.LoginUser;
 import com.masil.global.auth.dto.request.AuthTokenRequest;
 import com.masil.global.auth.dto.request.LoginRequest;
 import com.masil.global.auth.dto.request.SignupRequest;
 import com.masil.global.auth.dto.response.AuthTokenResponse;
+import com.masil.global.auth.dto.response.CurrentMember;
 import com.masil.global.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,8 +34,8 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public void logout() {
-        authService.logout();
+    public void logout(@LoginUser CurrentMember member) {
+        authService.logout(member);
     }
 
     @PostMapping("/reissue")

--- a/src/main/java/com/masil/global/auth/dto/request/AuthTokenRequest.java
+++ b/src/main/java/com/masil/global/auth/dto/request/AuthTokenRequest.java
@@ -2,17 +2,17 @@ package com.masil.global.auth.dto.request;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class AuthTokenRequest {
 
-    private String grantType;
     private String accessToken;
     private String refreshToken;
 
     @Builder
     public AuthTokenRequest(String grantType, String accessToken, String refreshToken) {
-        this.grantType = grantType;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
     }

--- a/src/main/java/com/masil/global/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/masil/global/auth/dto/request/SignupRequest.java
@@ -13,6 +13,8 @@ import java.util.Set;
 @Getter
 public class SignupRequest {
 
+    private final String NORMAL_STATE = "NORMAL";
+
     @NotBlank(message = "잘못된 이메일 값입니다.")
     private String email;
     @NotBlank(message = "잘못된 패스워드 값입니다.")
@@ -37,6 +39,7 @@ public class SignupRequest {
         return Member.builder()
                 .email(email)
                 .password(encoder.encode(password))
+                .state(NORMAL_STATE)
                 .nickname(nickname)
                 .authorities(authorities)
                 .build();

--- a/src/main/java/com/masil/global/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/masil/global/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.masil.global.auth.jwt.filter;
 
+import com.masil.global.auth.jwt.properties.JwtProperties;
 import com.masil.global.auth.jwt.provider.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +13,7 @@ import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.PrintWriter;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,6 +24,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        // TODO: 2023/02/06 추후 변경하기  
+        String header = request.getHeader(AUTHORIZATION_HEADER);
+        if (header == null || !header.startsWith(BEARER_PREFIX)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
         String token = resolveToken(request);
         log.debug("token = {}", token);
 
@@ -30,6 +39,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             this.setAuthentication(token);
         }
         filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return request.getServletPath().equals("/addresses/test");
     }
 
     /**

--- a/src/main/java/com/masil/global/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/masil/global/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -37,13 +37,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
             // 토큰 유효함
             this.setAuthentication(token);
+        } else {
+
         }
         filterChain.doFilter(request, response);
     }
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        return request.getServletPath().equals("/addresses/test");
+        return request.getServletPath().startsWith("/auth");
+        /*
+
+         */
     }
 
     /**

--- a/src/main/java/com/masil/global/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/masil/global/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -34,7 +34,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
         log.debug("token = {}", token);
 
-        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+        if (StringUtils.hasText(token)) {
+            jwtTokenProvider.validateTokenOnFilter(token);
             // 토큰 유효함
             this.setAuthentication(token);
         } else {

--- a/src/main/java/com/masil/global/auth/jwt/filter/JwtExceptionHandlerFilter.java
+++ b/src/main/java/com/masil/global/auth/jwt/filter/JwtExceptionHandlerFilter.java
@@ -1,0 +1,54 @@
+package com.masil.global.auth.jwt.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.masil.global.error.exception.ErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import lombok.Getter;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            //토큰의 유효기간 만료
+            setErrorResponse(response, ErrorCode.TOKEN_EXPIRED);
+        } catch (JwtException | IllegalArgumentException e) {
+            //유효하지 않은 토큰
+            setErrorResponse(response, ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        JwtErrorResponse errorResponse = new JwtErrorResponse(errorCode.getCode(), errorCode.getMessage());
+        try {
+            response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Getter
+    public static class JwtErrorResponse {
+        private final Integer code;
+        private final String message;
+
+        public JwtErrorResponse(Integer code, String message) {
+            this.code = code;
+            this.message = message;
+        }
+    }
+}

--- a/src/main/java/com/masil/global/auth/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/masil/global/auth/jwt/provider/JwtTokenProvider.java
@@ -111,19 +111,16 @@ public class JwtTokenProvider {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
-        } catch (SignatureException ex){
-            throw new BusinessException("Invalid JWT signature", ErrorCode.INVALID_INPUT_VALUE);
-        } catch (MalformedJwtException ex) {
-            throw new BusinessException("Invalid JWT token", ErrorCode.INVALID_INPUT_VALUE);
         } catch (ExpiredJwtException ex) {
-            throw new BusinessException("Expired JWT token", ErrorCode.INVALID_INPUT_VALUE);
-        } catch (UnsupportedJwtException ex) {
-            throw new BusinessException("Unsupported JWT token", ErrorCode.INVALID_INPUT_VALUE);
-        } catch (IllegalArgumentException ex) {
-            throw new BusinessException("JWT claims string is empty.", ErrorCode.INVALID_INPUT_VALUE);
+            throw new BusinessException(ErrorCode.TOKEN_EXPIRED);
+        } catch (JwtException ex) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
         }
     }
 
+    public void validateTokenOnFilter(String token) {
+        Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+    }
 
     /**
      *

--- a/src/main/java/com/masil/global/auth/service/AuthService.java
+++ b/src/main/java/com/masil/global/auth/service/AuthService.java
@@ -47,10 +47,19 @@ public class AuthService {
         authorites.add(authorityRepository.findByAuthorityName(MemberAuthType.ROLE_USER)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE)));
 
+
+        validateSignRequest(createRequest);
+        memberRepository.save(createRequest.convertMember(passwordEncoder, authorites));
+    }
+
+    private void validateSignRequest(SignupRequest createRequest) {
         if (checkDuplicateEmail(createRequest)) {
             throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
         }
-        memberRepository.save(createRequest.convertMember(passwordEncoder, authorites));
+
+        if (!createRequest.getPassword().equals(createRequest.getPasswordConfirm())) {
+            throw new BusinessException(ErrorCode.NOT_SAME_PASSWORD_CONFIRM);
+        }
     }
 
     private boolean checkDuplicateEmail(SignupRequest createRequest) {

--- a/src/main/java/com/masil/global/auth/service/AuthService.java
+++ b/src/main/java/com/masil/global/auth/service/AuthService.java
@@ -41,15 +41,14 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public void signUp(SignupRequest createRequest) {
+    public void signUp(SignupRequest signupRequest) {
         Set<Authority> authorites = new HashSet<>();
 
         authorites.add(authorityRepository.findByAuthorityName(MemberAuthType.ROLE_USER)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE)));
 
-
-        validateSignRequest(createRequest);
-        memberRepository.save(createRequest.convertMember(passwordEncoder, authorites));
+        validateSignRequest(signupRequest);
+        memberRepository.save(signupRequest.convertMember(passwordEncoder, authorites));
     }
 
     private void validateSignRequest(SignupRequest createRequest) {
@@ -60,6 +59,14 @@ public class AuthService {
         if (!createRequest.getPassword().equals(createRequest.getPasswordConfirm())) {
             throw new BusinessException(ErrorCode.NOT_SAME_PASSWORD_CONFIRM);
         }
+
+        if (checkDuplicateNickName(createRequest)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+    }
+
+    private boolean checkDuplicateNickName(SignupRequest createRequest) {
+        return memberRepository.findByNickname(createRequest.getNickname()).isPresent();
     }
 
     private boolean checkDuplicateEmail(SignupRequest createRequest) {

--- a/src/main/java/com/masil/global/auth/service/AuthService.java
+++ b/src/main/java/com/masil/global/auth/service/AuthService.java
@@ -127,12 +127,12 @@ public class AuthService {
 
             // 3. 저장소에서 Member Email 를 기반으로 Refresh Token 값 가져옴
             RefreshToken refreshToken = refreshTokenRepository.findByKey(authentication.getName())
-                    .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE)); // 로그 아웃된 사용자
+                    .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN)); // 로그 아웃된 사용자
 
 
             // 4. Refresh Token 일치하는지 검사
             if (!refreshToken.getValue().equals(orgRefreshToken)) {
-                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE); // 토큰이 일치하지 않습니다.
+                throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN); // 토큰이 일치하지 않습니다.
             }
 
             // 5. 새로운 토큰 생성
@@ -148,10 +148,9 @@ public class AuthService {
 
             // 6. 저장소 정보 업데이트 (dirtyChecking으로 업데이트)
             refreshToken.updateValue(newRefreshToken);
-
             return tokenResponse;
         } else {
-            throw new BusinessException("Invalid JWT token", ErrorCode.INVALID_INPUT_VALUE);
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
     }
 

--- a/src/main/java/com/masil/global/config/security/JwtSecurityConfig.java
+++ b/src/main/java/com/masil/global/config/security/JwtSecurityConfig.java
@@ -1,6 +1,7 @@
 package com.masil.global.config.security;
 
 import com.masil.global.auth.jwt.filter.JwtAuthenticationFilter;
+import com.masil.global.auth.jwt.filter.JwtExceptionHandlerFilter;
 import com.masil.global.auth.jwt.provider.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
@@ -17,5 +18,6 @@ public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurity
     public void configure(HttpSecurity http) throws Exception {
         JwtAuthenticationFilter jwtFilter = new JwtAuthenticationFilter(tokenProvider);
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new JwtExceptionHandlerFilter(), JwtAuthenticationFilter.class);
     }
 }

--- a/src/main/java/com/masil/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/masil/global/config/security/SecurityConfig.java
@@ -45,20 +45,21 @@ public class SecurityConfig {
                 .configurationSource(corsConfigurationSource())
                 .and()
 
-                .httpBasic().disable()
+                .formLogin().disable()
+                .httpBasic().disable() // httpBasic 방식 : Authorization header 값에 id , pw 값 전달하는 방식
                 .csrf().disable()
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
 
+                // TODO: 2023/02/06 추후 authenticate url 패턴 이야기 나누기
                 .authorizeRequests()
                 .antMatchers(
                         "/auth/login",
-                        "/",
-                        "/boards/*/posts/*",
-                        "/boards/*/posts",
-                        "/posts/*/comments"
-                ).permitAll()
+                        "/boards/**/posts/**",
+                        "/boards/**/posts",
+                        "/posts/**/comments"
+                ).authenticated()
                 .anyRequest().permitAll()
                 .and()
 

--- a/src/main/java/com/masil/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/masil/global/config/security/SecurityConfig.java
@@ -55,14 +55,17 @@ public class SecurityConfig {
                 // TODO: 2023/02/06 추후 authenticate url 패턴 이야기 나누기
                 .authorizeRequests()
                 .antMatchers(
-                        "/auth/login",
+                        "/auth/**",
                         "/boards/**/posts/**",
+                        // 비회원 포스트 컨트롤러가 있고
+                        // 토큰이 필요 없는 서비스 uri 패턴만 넣어놓기
                         "/boards/**/posts",
-                        "/posts/**/comments"
-                ).authenticated()
-                .anyRequest().permitAll()
+                        "/posts/**/comments",
+                        "/posts/**"
+                        //
+                ).permitAll()
+                .anyRequest().authenticated()
                 .and()
-
                 .apply(new JwtSecurityConfig(jwtTokenProvider));
 
         return http.build();

--- a/src/main/java/com/masil/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/masil/global/error/exception/ErrorCode.java
@@ -39,7 +39,12 @@ public enum ErrorCode {
     // address
     INVALID_ADDRESS_SEARCH_KEYWORD(BAD_REQUEST, 8001, "잘못된 검색어 입니다."),
 
-    // auth;
+    // auth
+    TOKEN_EXPIRED(BAD_REQUEST,6001,"토큰 유효기간이 지났습니다."),
+
+    INVALID_TOKEN(BAD_REQUEST, 6002, "잘못된 토큰입니다."),
+
+    INVALID_REFRESH_TOKEN(BAD_REQUEST,6003,"잘못된 리프레쉬 토큰입니다"),
 
     ;
     private HttpStatus status;

--- a/src/main/java/com/masil/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/masil/global/error/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     // member
     MEMBER_NOT_FOUND(NOT_FOUND, 2001, "존재하지 않는 사용자입니다."),
     DUPLICATE_EMAIL(BAD_REQUEST, 2002, "중복된 이메일 입니다."),
+    DUPLICATE_NICKNAME(BAD_REQUEST, 2003, "중복된 닉네임입니다."),
     NOT_SAME_PASSWORD_CONFIRM(BAD_REQUEST, 2003, "비밀번호와 비밀번호 확인 값이 다릅니다."),
     // post
     POST_NOT_FOUND(NOT_FOUND, 3001, "존재하지 않는 게시글입니다."),
@@ -38,7 +39,7 @@ public enum ErrorCode {
     // address
     INVALID_ADDRESS_SEARCH_KEYWORD(BAD_REQUEST, 8001, "잘못된 검색어 입니다."),
 
-    // auth
+    // auth;
 
     ;
     private HttpStatus status;

--- a/src/main/java/com/masil/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/masil/global/error/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     // member
     MEMBER_NOT_FOUND(NOT_FOUND, 2001, "존재하지 않는 사용자입니다."),
     DUPLICATE_EMAIL(BAD_REQUEST, 2002, "중복된 이메일 입니다."),
+    NOT_SAME_PASSWORD_CONFIRM(BAD_REQUEST, 2003, "비밀번호와 비밀번호 확인 값이 다릅니다."),
     // post
     POST_NOT_FOUND(NOT_FOUND, 3001, "존재하지 않는 게시글입니다."),
     POST_ACCESS_DENIED(FORBIDDEN, 3002, "해당 게시글에 대한 권한이 없습니다"),

--- a/src/main/java/com/masil/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/masil/global/error/exception/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
 
     // member
     MEMBER_NOT_FOUND(NOT_FOUND, 2001, "존재하지 않는 사용자입니다."),
-
+    DUPLICATE_EMAIL(BAD_REQUEST, 2002, "중복된 이메일 입니다."),
     // post
     POST_NOT_FOUND(NOT_FOUND, 3001, "존재하지 않는 게시글입니다."),
     POST_ACCESS_DENIED(FORBIDDEN, 3002, "해당 게시글에 대한 권한이 없습니다"),
@@ -37,6 +37,7 @@ public enum ErrorCode {
     // address
     INVALID_ADDRESS_SEARCH_KEYWORD(BAD_REQUEST, 8001, "잘못된 검색어 입니다."),
 
+    // auth
 
     ;
     private HttpStatus status;

--- a/src/test/java/com/masil/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/masil/domain/member/service/MemberServiceTest.java
@@ -1,38 +1,61 @@
 package com.masil.domain.member.service;
 
+import com.masil.domain.member.dto.request.MemberAddressRequest;
+import com.masil.domain.member.entity.Member;
 import com.masil.domain.member.repository.MemberRepository;
+import com.masil.global.auth.dto.request.SignupRequest;
+import com.masil.global.auth.service.AuthService;
+import com.masil.global.error.exception.EntityNotFoundException;
+import com.masil.global.error.exception.ErrorCode;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
+@ActiveProfiles("test")
 @SpringBootTest
+@Transactional
 class MemberServiceTest {
 
     @Autowired
     private MemberService memberService;
 
     @Autowired
+    private AuthService authService;
+
+    @Autowired
     private MemberRepository memberRepository;
 
     @Test
-    @DisplayName("이메일 중복으로 인한 회원가입 실패")
-    void saveUserFailBecauseDuplicateEmail () throws Exception {
+    @DisplayName("주소 등록 및 수정 성공")
+    void memberAddressModifySuccess () throws Exception {
         //given
+        SignupRequest signReq = SignupRequest.builder()
+                .email("테스트아이디")
+                .password("1234")
+                .passwordConfirm("1234")
+                .nickname("닉네임1234")
+                .build();
+        authService.signUp(signReq);
+        Member savedMember = memberRepository.findByEmail(signReq.getEmail())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        Integer emdId = 11110108;
+
+        MemberAddressRequest addressRequest = MemberAddressRequest.builder()
+                .emdId(emdId)
+                .build();
 
         //when
+        memberService.modifyMemberAddress(savedMember.getId(), addressRequest);
 
         //then
+        Member member = memberRepository.findByEmail(signReq.getEmail())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        Assertions.assertEquals(emdId,member.getEmdAddress().getId());
     }
-
-    @Test
-    @DisplayName("비밀번호 양식 잘못 입력으로 인한 회원가입 실패")
-    void saveUserFailBecauseWrongPasswordPattern () throws Exception {
-        //given
-
-        //when
-
-        //then
-    }
-
 }

--- a/src/test/java/com/masil/global/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/masil/global/auth/service/AuthServiceTest.java
@@ -9,6 +9,8 @@ import com.masil.global.auth.dto.response.AuthTokenResponse;
 import com.masil.global.auth.entity.Authority;
 import com.masil.global.auth.model.MemberAuthType;
 import com.masil.global.auth.repository.AuthorityRepository;
+import com.masil.global.error.exception.BusinessException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -50,11 +52,13 @@ class AuthServiceTest extends ServiceTest{
         //given
         String testEmail = "test@gmail.com";
         String testPassword = "test@1234";
+        String testPasswordConfirm = "test@1234";
         String testNickName = "테스트닉네임";
 
         SignupRequest createRequest = SignupRequest.builder()
                 .email(testEmail)
                 .password(testPassword)
+                .passwordConfirm(testPasswordConfirm)
                 .nickname(testNickName)
                 .build();
 
@@ -75,13 +79,50 @@ class AuthServiceTest extends ServiceTest{
     }
     
     @Test
-    @DisplayName("이메일이나 비밀번호가 유효하지 않을 경우 실패")
-    void loginFailBecauseBadRequest () throws Exception {
+    @DisplayName("이메일 중복오류 테스트")
+    void loginFailBecauseDuplicateEmail () throws Exception {
         //given
-        
-        //when
-        
+
+        String testEmail = "test@gmail.com";
+        String testPassword = "test@1234";
+        String testPasswordConfirm = "test@1234";
+        String testNickName = "테스트닉네임";
+
+        SignupRequest createRequest = SignupRequest.builder()
+                .email(testEmail)
+                .password(testPassword)
+                .passwordConfirm(testPasswordConfirm)
+                .nickname(testNickName)
+                .build();
+
+        authService.signUp(createRequest);
+
         //then
+        Assertions.assertThatThrownBy(() -> authService.signUp(SignupRequest.builder()
+                .email(testEmail)
+                .password("234wetwer23")
+                .passwordConfirm("234wetwer23")
+                .nickname("닉네임")
+                .build())).isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("회원가입시 비밀번호 , 비밀번호 확인이 다를 경우")
+    void signupFailBecauseNotEqualPasswordAndPasswordConfirm () throws Exception {
+        //given
+        String testEmail = "test@gmail.com";
+        String testPassword = "test@1234";
+        String testPasswordConfirm = "test@12345";
+        String testNickName = "테스트닉네임";
+
+        //when
+        Assertions.assertThatThrownBy(() -> authService.signUp(SignupRequest.builder()
+                .email(testEmail)
+                .password(testPassword)
+                .passwordConfirm(testPasswordConfirm)
+                .nickname(testNickName)
+                .build())).isInstanceOf(BusinessException.class);
+
     }
 
     @Test


### PR DESCRIPTION
# 작업 내용
1. 토큰 jwt 필터 exception 핸들러 추가 ( 필터에서 exception이 날 때 ControllerAdvice 에서 못잡는다 따로 핸들러가 필요 ) 
2. 재발행 로직 변경 
3. 로그인 시 RefreshToken 저장 ( 있을 시 수정 ) 
4. 주소 등록 API 기능 추가 
5. Security Config 리팩토링 -> 추후 이야기 후 다시 리팩토링 진행 필요

해당 PR 머지 후 서버 .yml 파일안에 있는 token-expire-time 수정 진행하겠습니다. 현재 만료 기한을 액세스 토큰과 리프레쉬 토큰 둘다 1일로 진행해놓은 상태 머지 후 액세스 토큰은 1분 리프레쉬 토큰은 5분으로 진행해서 테스트 하겠습니다 테스트 후 리프레쉬 토큰은 1일 액세스 토큰은 5분으로 변경하겠습니다.
# 참고 사항

# 스크린샷

Closes 이슈번호
