### PR TITLE
Refactor :  post 관련 리펙토링

### DIFF
--- a/src/main/java/com/masil/domain/board/entity/Board.java
+++ b/src/main/java/com/masil/domain/board/entity/Board.java
@@ -22,8 +22,7 @@ public class Board extends BaseEntity {
     private String name;
 
     @Builder
-    private Board(Long id, String name) {
-        this.id = id;
+    private Board(String name) {
         this.name = name;
     }
 }

--- a/src/main/java/com/masil/domain/post/entity/Post.java
+++ b/src/main/java/com/masil/domain/post/entity/Post.java
@@ -94,9 +94,6 @@ public class Post extends BaseEntity {
         return this.member.getId() == memberId;
     }
 
-    public void plusView() {
-        this.viewCount++;
-    }
     public void plusLike() {
         this.likeCount++;
     }

--- a/src/main/java/com/masil/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/masil/domain/post/repository/PostRepository.java
@@ -1,10 +1,11 @@
 package com.masil.domain.post.repository;
 
 import com.masil.domain.post.entity.Post;
-import com.masil.domain.post.entity.State;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,4 +14,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Slice<Post> findAllByBoardIdAndEmdAddressId(Long boardId, Integer emdAddressId, Pageable pageable);
 
     Slice<Post> findAllByBoardIdAndEmdAddressSggAddressId(Long boardId, Integer sggAddressId, Pageable pageable);
+
+    @Modifying
+    @Query(value = "UPDATE Post p set p.viewCount = p.viewCount + 1 where p.id = :postId")
+    void increaseViewCount(Long postId);
 }

--- a/src/main/java/com/masil/domain/post/service/PostService.java
+++ b/src/main/java/com/masil/domain/post/service/PostService.java
@@ -8,7 +8,6 @@ import com.masil.domain.member.exception.MemberNotFoundException;
 import com.masil.domain.member.repository.MemberRepository;
 import com.masil.domain.post.dto.*;
 import com.masil.domain.post.entity.Post;
-import com.masil.domain.post.entity.State;
 import com.masil.domain.post.exception.PostAccessDeniedException;
 import com.masil.domain.post.exception.PostNotFoundException;
 import com.masil.domain.post.repository.PostRepository;
@@ -28,7 +27,10 @@ public class PostService {
     private final PostLikeRepository postLikeRepository;
     private final BoardRepository boardRepository;
 
+    @Transactional
     public PostDetailResponse findDetailPost(Long postId, Long memberId) {
+        postRepository.increaseViewCount(postId);
+
         Post post = findPostById(postId);
         checkPostState(post);
 
@@ -36,8 +38,6 @@ public class PostService {
         if (memberId != null) {
             updatePostPermissionsForMember(memberId, post);
         }
-
-        post.plusView();
 
         return PostDetailResponse.of(post);
     }

--- a/src/test/java/com/masil/domain/fixture/BoardFixture.java
+++ b/src/test/java/com/masil/domain/fixture/BoardFixture.java
@@ -1,0 +1,27 @@
+package com.masil.domain.fixture;
+
+import com.masil.domain.board.entity.Board;
+import com.masil.domain.member.entity.Member;
+
+public enum BoardFixture {
+    전체_카테고리(1L, "전체"),
+    동네소식_카테고리(2L, "동네소식"),
+    동네질문_카테고리(3L, "동네질문"),
+    일상_카테고리(4L, "일상"),
+    분실_실종_카테고리(5L, "분실/실종")
+    ;
+
+    private final Long id;
+    private final String name;
+
+    BoardFixture(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Board 엔티티_생성() {
+        return Board.builder()
+                .name(this.name)
+                .build();
+    }
+}

--- a/src/test/java/com/masil/domain/fixture/MemberFixture.java
+++ b/src/test/java/com/masil/domain/fixture/MemberFixture.java
@@ -1,0 +1,27 @@
+package com.masil.domain.fixture;
+
+import com.masil.domain.address.entity.EmdAddress;
+import com.masil.domain.member.entity.Member;
+
+public enum MemberFixture {
+    일반_회원_JJ("jj123@gmail.com", "jj123123!", "지지"),
+    일반_회원_KK("kk123@gmail.com", "kk123123!", "케이케이")
+    ;
+
+    private final String email;
+    private final String password;
+    private final String nickname;
+
+    MemberFixture(String email, String password, String nickname) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+    }
+    public Member 엔티티_생성() {
+        return Member.builder()
+                .email(this.email)
+                .password(this.password)
+                .nickname(this.nickname)
+                .build();
+    }
+}

--- a/src/test/java/com/masil/domain/fixture/PostFixture.java
+++ b/src/test/java/com/masil/domain/fixture/PostFixture.java
@@ -1,0 +1,68 @@
+package com.masil.domain.fixture;
+
+import com.masil.domain.address.entity.EmdAddress;
+import com.masil.domain.board.entity.Board;
+import com.masil.domain.member.entity.Member;
+import com.masil.domain.post.entity.Post;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public enum PostFixture {
+    일반_게시글_JJ(MemberFixture.일반_회원_JJ.엔티티_생성(), "일반 게시글 내용", BoardFixture.전체_카테고리.엔티티_생성()),
+    일반_게시글_KK(MemberFixture.일반_회원_KK.엔티티_생성(), "일반 게시글 내용", BoardFixture.전체_카테고리.엔티티_생성())
+    ;
+
+    private final Member member;
+    private final String content;
+    private final Board board;
+
+    PostFixture(Member member, String content, Board board) {
+        this.member = member;
+        this.content = content;
+        this.board = board;
+    }
+
+    // TODO : emd 파라미터로 받는 거 나중에 수정 02-11
+    public Post 엔티티_생성(EmdAddress emdAddress) {
+
+        return Post.builder()
+                .content(this.content)
+                .member(this.member)
+                .board(this.board)
+                .emdAddress(emdAddress)
+                .build();
+    }
+    public Post 엔티티_생성() {
+
+        return Post.builder()
+                .content(this.content)
+                .member(this.member)
+                .build();
+    }
+
+    public List<Post> 엔티티_여러개_생성(EmdAddress emdAddress) {
+        List<Post> posts = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            posts.add(
+                    Post.builder()
+                            .content(this.content)
+                            .member(this.member)
+                            .board(this.board)
+                            .emdAddress(emdAddress)
+                            .build()
+            );
+        }
+        return posts;
+    }
+
+    public Member 멤버() {
+        return this.member;
+    }
+    public String 내용() {
+        return this.content;
+    }
+    public Board 카테고리() {
+        return this.board;
+    }
+}

--- a/src/test/java/com/masil/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/masil/domain/post/service/PostServiceTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,6 +40,9 @@ public class PostServiceTest extends ServiceTest {
     private PostLikeService postLikeService;
     @Autowired
     private EmdAddressRepository emdAddressRepository; // 임시
+
+    @PersistenceContext
+    private EntityManager em;
 
     private static final String POST_CONTENT_1 = "내용1";
     private static final String POST_CONTENT_2 = "내용2";
@@ -91,17 +96,32 @@ public class PostServiceTest extends ServiceTest {
 
         // when
         PostDetailResponse postDetailResponse = postService.findDetailPost(1L, 2L);
+        Post post = postRepository.findById(postDetailResponse.getId()).get();
 
         // then
-        assertThat(postDetailResponse.getId()).isEqualTo(1L);
-        assertThat(postDetailResponse.getMember().getId()).isEqualTo(1L);
-        assertThat(postDetailResponse.getMember().getNickname()).isEqualTo(USER_NICKNAME_1);
-        assertThat(postDetailResponse.getBoardId()).isEqualTo(1L);
-        assertThat(postDetailResponse.getContent()).isEqualTo(POST_CONTENT_1);
-        assertThat(postDetailResponse.getViewCount()).isEqualTo(1);
-        assertThat(postDetailResponse.getLikeCount()).isEqualTo(0);
-        assertThat(postDetailResponse.getIsOwner()).isEqualTo(false);
-        assertThat(postDetailResponse.getIsLiked()).isEqualTo(false);
+        assertThat(post.getId()).isEqualTo(1L);
+        assertThat(post.getMember().getId()).isEqualTo(1L);
+        assertThat(post.getMember().getNickname()).isEqualTo(USER_NICKNAME_1);
+        assertThat(post.getBoard().getId()).isEqualTo(1L);
+        assertThat(post.getViewCount()).isEqualTo(1L);
+        assertThat(post.getContent()).isEqualTo(POST_CONTENT_1);
+        assertThat(post.getLikeCount()).isEqualTo(0);
+        assertThat(post.getIsOwner()).isEqualTo(false);
+        assertThat(post.getIsLiked()).isEqualTo(false);
+    }
+
+    @DisplayName("게시글 조회시 조회수 1 증가.")
+    @Test
+    void findPost_increase_viewCount() {
+
+        // when
+        PostDetailResponse postDetailResponse = postService.findDetailPost(1L, 2L);
+
+        em.clear();
+        Post post = postRepository.findById(postDetailResponse.getId()).get();
+
+        // then
+        assertThat(post.getViewCount()).isEqualTo(1);
     }
 
     @DisplayName("존재하지 않는 게시글일 경우 예외가 발생한다")


### PR DESCRIPTION
# 작업 내용
1. 조회수 수정
    - post 조회수 작동 안 하는 이유 -> transaction이 read-only=true여서 false로 수정했습니다
    - 조회수 증가시 쿼리문에 모든 컬럼이 update되는 상황에서 viewCount만 수정되도록 개선했습니다 
    - Query문으로 JPQL문법 사용, 근데 JPQL은 기존 jpa랑 관리되는 방식이 다르게 때문에 좀 더 공부할 예정입니다.

2. service 단 테스트 코드 수정
    - https://github.dev/giibeom/project-NMJ-renewal/tree/develop/src 저번에 본 깃 참고하여 수정하였습니다.
    - fixture 도 임시로 만들었는데 좀 더 얘기를 나눠보고 수정을 해야될 거 같습니다.
    - 이 부분은 좀 더 얘기를 나눠보고 싶네요.
    - 가독성이 좋아지고 fixture덕분에 객체 생성이 쉬워졌습니다. 하지만 성능이 좋아지지는 않았습니다
    - assertThar여러개일 경우 assertAll로 묶어주었습니다. asserAll을 쓰면 쉽게 에러난 위치를 알 수 있습니다.
      - https://zzang9ha.tistory.com/418
      - assertSoftly도 사용해봤는데 성능이 정말 안 좋아서 비추천드립니다.
3. board엔티티 builder에 id제거했습니다.
4. postlike 코드 개선했습니다


Closes 이슈번호
#73 
