### PR TITLE
feat : comment 조회 부모댓글 deleted 추가 (#76)

### DIFF
--- a/src/main/java/com/masil/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/masil/domain/comment/controller/CommentController.java
@@ -7,7 +7,6 @@ import com.masil.global.auth.dto.response.CurrentMember;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.net.URI;
-import java.util.List;
 
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
@@ -34,7 +32,7 @@ public class CommentController {
      */
     @GetMapping("/{postId}/comments")
     public ResponseEntity<CommentsResponse> findComments(@PathVariable Long postId,
-                                                                @PageableDefault(page = 0, size = 10, direction = DESC) Pageable pageable,
+                                                                @PageableDefault(page = 0, size = 20, direction = DESC) Pageable pageable,
                                                                 @LoginUser CurrentMember currentMember){
 
         log.info("댓글 조회 시작");

--- a/src/main/java/com/masil/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/masil/domain/comment/dto/CommentResponse.java
@@ -4,6 +4,7 @@ package com.masil.domain.comment.dto;
 import com.masil.domain.comment.entity.Comment;
 import com.masil.domain.member.dto.response.MemberResponse;
 import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @Getter
 @ToString
+@Slf4j
 public class CommentResponse {
 
     private Long id;
@@ -26,11 +28,11 @@ public class CommentResponse {
     private LocalDateTime createDate;
     private LocalDateTime modifyDate;
 
-//    private boolean isDeleted; // 자식이 있을경우 삭제되면 true, 삭제 안됐을 경우 false
+    private boolean isDeleted; // 자식이 있을경우 삭제되면 true, 삭제 안됐을 경우 false
     private List<ChildrenResponse> replies;
 
     @Builder
-    public CommentResponse(Long id, Long postId, String content, MemberResponse member, boolean isOwner, int likeCount, boolean isLiked, LocalDateTime createDate, LocalDateTime modifyDate, List<ChildrenResponse> replies) {
+    public CommentResponse(Long id, Long postId, String content, MemberResponse member, boolean isOwner, int likeCount, boolean isLiked, LocalDateTime createDate, LocalDateTime modifyDate, boolean isDeleted, List<ChildrenResponse> replies) {
         this.id = id;
         this.postId = postId;
         this.content = content;
@@ -40,11 +42,13 @@ public class CommentResponse {
         this.isLiked = isLiked;
         this.createDate = createDate;
         this.modifyDate = modifyDate;
+        this.isDeleted = isDeleted;
         this.replies = replies;
     }
 
     public static CommentResponse of(Comment comment) {
         List<Comment> children = comment.getChildren(); // comment에서 children 을 받아온다.
+        log.info("comment = {}", comment.getId());
         List<ChildrenResponse> replies = children.stream()
                 .map(ChildrenResponse::of)
                 .collect(Collectors.toList());
@@ -57,6 +61,7 @@ public class CommentResponse {
                 .isOwner(comment.getIsOwner())
                 .likeCount(comment.getLikeCount())
                 .isLiked(comment.getIsLiked())
+                .isDeleted(comment.isNotAvailable())
                 .createDate(comment.getCreateDate())
                 .modifyDate(comment.getModifyDate())
                 .replies(replies)

--- a/src/main/java/com/masil/domain/comment/entity/Comment.java
+++ b/src/main/java/com/masil/domain/comment/entity/Comment.java
@@ -1,5 +1,6 @@
 package com.masil.domain.comment.entity;
 
+import com.masil.domain.comment.dto.CommentResponse;
 import com.masil.domain.comment.exception.CommentInputException;
 import com.masil.domain.commentlike.entity.CommentLike;
 import com.masil.domain.member.entity.Member;
@@ -15,7 +16,6 @@ import org.hibernate.annotations.Where;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import static javax.persistence.FetchType.LAZY;
 
@@ -60,6 +60,7 @@ public class Comment extends BaseEntity {
     /**
      * commentLikes 추가
      */
+    @Builder.Default
     @OneToMany(mappedBy = "comment", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<CommentLike> commentLikes = new ArrayList<>();
 
@@ -142,17 +143,15 @@ public class Comment extends BaseEntity {
     }
 
     /**
-     * 추후 수정
+     * TODO:02/12
+     * 부모 댓글과 자식 댓글 삭제 로직
      */
-    public void deleteChild(Comment reply) {
-        reply.tempDelete();
+    public boolean isAvailable() {
+        return this.state.isAvailable();
     }
 
-    public boolean isParent() {
-        return Objects.isNull(parent);
+    public boolean isNotAvailable() {
+        return !this.state.isAvailable();
     }
 
-    public boolean hasNoReply() {
-        return children.isEmpty();
-    }
 }

--- a/src/main/java/com/masil/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/masil/domain/comment/repository/CommentRepository.java
@@ -1,15 +1,24 @@
 package com.masil.domain.comment.repository;
 
 import com.masil.domain.comment.entity.Comment;
+import org.hibernate.sql.Select;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import javax.validation.Valid;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    Page<Comment> findAllByPostIdAndParentIdNull(Long postId, Pageable pageable);
+
+    @Query(value = "select * from comment p " +
+            "left join comment c on p.id = c.parent_id " +
+            "where p.parent_id is null AND NOT (p.state = \"DELETE\" AND c.id is NULL) GROUP BY p.id, c.parent_id",
+            countQuery = "SELECT * from Comment c where c.parent_id is null",
+            nativeQuery = true)
+    Page<Comment> findAllByPostId(Long postId, Pageable pageable);
+//    Page<Comment> findAllByPostIdAndParentIdNull(Long postId, Pageable pageable);
 
     Long countByPostId(Long postId);
 }

--- a/src/main/java/com/masil/domain/post/entity/State.java
+++ b/src/main/java/com/masil/domain/post/entity/State.java
@@ -1,6 +1,16 @@
 package com.masil.domain.post.entity;
 
 public enum State {
-    NORMAL,
-    DELETE
+    NORMAL(true),
+    DELETE(false);
+
+    private final boolean available;
+
+    State(boolean available) {
+        this.available = available;
+    }
+
+    public boolean isAvailable() {
+        return available;
+    }
 }

--- a/src/main/java/com/masil/global/common/entity/BaseEntity.java
+++ b/src/main/java/com/masil/global/common/entity/BaseEntity.java
@@ -1,5 +1,6 @@
 package com.masil.global.common.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,6 +27,7 @@ public class BaseEntity {
 
     @CreatedDate
     private LocalDateTime createDate;
+
     @LastModifiedDate
     private LocalDateTime modifyDate;
 }

--- a/src/test/java/com/masil/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/masil/domain/comment/controller/CommentControllerTest.java
@@ -118,8 +118,8 @@ class CommentControllerTest extends ControllerMockApiTest{
                                 fieldWithPath("comments.[].replies.[].modifyDate").description("수정 날짜"),
                                 fieldWithPath("comments.[].replies.[].liked").description("좋아여 여부"),
                                 fieldWithPath("comments.[].replies.[].owner").description("본인 댓글 여부"),
-                                fieldWithPath("comments.[].deleted").description("본인 댓글 여부"),
-                                fieldWithPath("comments.[].liked").description("부모 댓글 삭제 여부"),
+                                fieldWithPath("comments.[].deleted").description("본인 댓글 삭제 여부"),
+                                fieldWithPath("comments.[].liked").description("좋아요 여부"),
                                 fieldWithPath("comments.[].owner").description("본인 댓글 여부"),
                                 fieldWithPath("totalCommentCount").description("댓글 갯수"),
                                 fieldWithPath("totalPage").description("게시글 총 페이지")

--- a/src/test/java/com/masil/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/masil/domain/comment/controller/CommentControllerTest.java
@@ -118,7 +118,8 @@ class CommentControllerTest extends ControllerMockApiTest{
                                 fieldWithPath("comments.[].replies.[].modifyDate").description("수정 날짜"),
                                 fieldWithPath("comments.[].replies.[].liked").description("좋아여 여부"),
                                 fieldWithPath("comments.[].replies.[].owner").description("본인 댓글 여부"),
-                                fieldWithPath("comments.[].liked").description("좋아여 여부"),
+                                fieldWithPath("comments.[].deleted").description("본인 댓글 여부"),
+                                fieldWithPath("comments.[].liked").description("부모 댓글 삭제 여부"),
                                 fieldWithPath("comments.[].owner").description("본인 댓글 여부"),
                                 fieldWithPath("totalCommentCount").description("댓글 갯수"),
                                 fieldWithPath("totalPage").description("게시글 총 페이지")


### PR DESCRIPTION
# 작업 내용
feat : comment 조회 부모댓글 deleted 추가 (#76)

# 참고 사항
부모 댓글은 삭제 시 자식댓글이 있다면 deleted = true 로 수정하여 자식댓글이 조회되도록 하였습니다.
@query에서 nativeQuery를 사용하면 페이징 처리가 되지 않아 createQuery를 사용해줬습니다.

https://chaezzing-fly-dev.tistory.com/39

# 스크린샷

Closes 76
