### PR TITLE
Feat : bookmark 기능 추가

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -121,3 +121,41 @@ include::{snippets}/post/like/selfLike/http-request.adoc[]
 ==== HTTP response
 
 include::{snippets}/post/like/selfLike/http-response.adoc[]
+
+= 2. 즐겨찾기
+
+== 2.1. 즐겨찾기 추가하기
+
+=== 2.1.1 즐겨찾기 추가하기 성공
+
+==== HTTP request
+
+include::{snippets}/bookmark/add/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/bookmark/add/http-response.adoc[]
+
+== 2.2. 즐겨찾기 삭제하기
+
+=== 2.2.1 즐겨찾기 삭제하기 성공
+
+==== HTTP request
+
+include::{snippets}/bookmark/delete/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/bookmark/delete/http-response.adoc[]
+
+== 2.3. 즐겨찾기 조회하기
+
+=== 2.3.1 즐겨찾기 조회하기 성공
+
+==== HTTP request
+
+include::{snippets}/bookmark/find/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/bookmark/find/http-response.adoc[]

--- a/src/main/java/com/masil/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/masil/domain/bookmark/controller/BookmarkController.java
@@ -1,9 +1,20 @@
 package com.masil.domain.bookmark.controller;
 
+import com.masil.domain.bookmark.dto.BookmarkResponse;
+import com.masil.domain.bookmark.dto.BookmarksResponse;
 import com.masil.domain.bookmark.service.BookmarkService;
+import com.masil.domain.post.dto.PostDetailResponse;
+import com.masil.global.auth.annotaion.LoginUser;
+import com.masil.global.auth.dto.response.CurrentMember;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @Slf4j
 @RestController
@@ -11,4 +22,34 @@ import org.springframework.web.bind.annotation.RestController;
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;
+
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/posts/{postId}/bookmark")
+    public ResponseEntity<BookmarkResponse> addBookmark(@PathVariable Long postId,
+                                                           @LoginUser CurrentMember currentMember) {
+        log.info("즐겨찾기 추가 시작");
+
+        BookmarkResponse bookmarkResponse = bookmarkService.addBookmark(postId, currentMember.getId());
+        return ResponseEntity.ok(bookmarkResponse);
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @DeleteMapping("/posts/{postId}/bookmark")
+    public ResponseEntity<BookmarkResponse> deleteBookmark(@PathVariable Long postId,
+                                                        @LoginUser CurrentMember currentMember) {
+        log.info("즐겨찾기 삭제 시작");
+
+        BookmarkResponse bookmarkResponse = bookmarkService.deleteBookmark(postId, currentMember.getId());
+        return ResponseEntity.ok(bookmarkResponse);
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/bookmarks")
+    public ResponseEntity<BookmarksResponse> findBookmarks(@LoginUser CurrentMember currentMember,
+                                                           @PageableDefault(sort = "createDate", direction = DESC) Pageable pageable) {
+        log.info("즐겨찾기 목록 조회 시작");
+
+        BookmarksResponse bookmarksResponse = bookmarkService.findBookmarks(currentMember.getId(), pageable);
+        return ResponseEntity.ok(bookmarksResponse);
+    }
 }

--- a/src/main/java/com/masil/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/masil/domain/bookmark/controller/BookmarkController.java
@@ -1,0 +1,14 @@
+package com.masil.domain.bookmark.controller;
+
+import com.masil.domain.bookmark.service.BookmarkService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+}

--- a/src/main/java/com/masil/domain/bookmark/dto/BookmarkResponse.java
+++ b/src/main/java/com/masil/domain/bookmark/dto/BookmarkResponse.java
@@ -1,0 +1,14 @@
+package com.masil.domain.bookmark.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BookmarkResponse {
+    private Boolean isScrap;
+
+    public static BookmarkResponse of(Boolean isScrap) {
+        return new BookmarkResponse(isScrap);
+    }
+}

--- a/src/main/java/com/masil/domain/bookmark/dto/BookmarksElementResponse.java
+++ b/src/main/java/com/masil/domain/bookmark/dto/BookmarksElementResponse.java
@@ -1,0 +1,34 @@
+package com.masil.domain.bookmark.dto;
+
+import com.masil.domain.bookmark.entity.Bookmark;
+import com.masil.domain.member.dto.response.MemberResponse;
+import com.masil.domain.post.entity.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class BookmarksElementResponse {
+    private Long id;
+    private MemberResponse member;
+    private Long boardId;
+    private String address;
+    private String content;
+    private LocalDateTime createDate;
+    private LocalDateTime modifyDate;
+
+    public static BookmarksElementResponse of(Bookmark bookmark) {
+        Post post = bookmark.getPost();
+        return BookmarksElementResponse.builder()
+                .id(post.getId())
+                .member(MemberResponse.of(post.getMember()))
+                .boardId(post.getBoard().getId())
+                .address(post.getEmdAddress().getEmdName())
+                .content(post.getPostPreview())
+                .createDate(post.getCreateDate())
+                .modifyDate(post.getModifyDate())
+                .build();
+    }
+}

--- a/src/main/java/com/masil/domain/bookmark/dto/BookmarksElementResponse.java
+++ b/src/main/java/com/masil/domain/bookmark/dto/BookmarksElementResponse.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class BookmarksElementResponse {
-    private Long id;
+    private Long postId;
     private MemberResponse member;
     private Long boardId;
     private String address;
@@ -22,7 +22,7 @@ public class BookmarksElementResponse {
     public static BookmarksElementResponse of(Bookmark bookmark) {
         Post post = bookmark.getPost();
         return BookmarksElementResponse.builder()
-                .id(post.getId())
+                .postId(post.getId())
                 .member(MemberResponse.of(post.getMember()))
                 .boardId(post.getBoard().getId())
                 .address(post.getEmdAddress().getEmdName())

--- a/src/main/java/com/masil/domain/bookmark/dto/BookmarksResponse.java
+++ b/src/main/java/com/masil/domain/bookmark/dto/BookmarksResponse.java
@@ -1,0 +1,31 @@
+package com.masil.domain.bookmark.dto;
+
+import com.masil.domain.bookmark.entity.Bookmark;
+import com.masil.domain.post.dto.PostsElementResponse;
+import com.masil.domain.post.entity.Post;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class BookmarksResponse {
+
+    private List<BookmarksElementResponse> bookmarks;
+    private Boolean isLast;
+
+    public BookmarksResponse(List<BookmarksElementResponse> bookmarks, boolean isLast) {
+        this.bookmarks = bookmarks;
+        this.isLast = isLast;
+    }
+    public static BookmarksResponse ofBookmarks(Slice<Bookmark> bookmarks) {
+        List<BookmarksElementResponse> postsResponse = bookmarks
+                .stream()
+                .map(bookmark -> BookmarksElementResponse.of(bookmark))
+                .collect(Collectors.toList());
+
+        return new BookmarksResponse(postsResponse, bookmarks.isLast());
+    }
+
+}

--- a/src/main/java/com/masil/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/masil/domain/bookmark/entity/Bookmark.java
@@ -1,9 +1,12 @@
-package com.masil.domain.postlike.entity;
+package com.masil.domain.bookmark.entity;
 
 import com.masil.domain.member.entity.Member;
 import com.masil.domain.post.entity.Post;
 import com.masil.global.common.entity.BaseEntity;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
@@ -12,8 +15,7 @@ import javax.persistence.*;
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PostLike extends BaseEntity {
-
+public class Bookmark extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -27,9 +29,8 @@ public class PostLike extends BaseEntity {
     private Post post;
 
     @Builder
-    public PostLike(Post post, Member member) {
+    public Bookmark(Post post, Member member) {
         this.post = post;
         this.member = member;
     }
-
 }

--- a/src/main/java/com/masil/domain/bookmark/exception/BookmarkAlreadyExistsException.java
+++ b/src/main/java/com/masil/domain/bookmark/exception/BookmarkAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package com.masil.domain.bookmark.exception;
+
+import com.masil.global.error.exception.BusinessException;
+import com.masil.global.error.exception.ErrorCode;
+
+public class BookmarkAlreadyExistsException extends BusinessException {
+    public BookmarkAlreadyExistsException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/masil/domain/bookmark/exception/BookmarkNotFoundException.java
+++ b/src/main/java/com/masil/domain/bookmark/exception/BookmarkNotFoundException.java
@@ -1,0 +1,11 @@
+package com.masil.domain.bookmark.exception;
+
+import com.masil.global.error.exception.EntityNotFoundException;
+import com.masil.global.error.exception.ErrorCode;
+
+public class BookmarkNotFoundException extends EntityNotFoundException {
+
+    public BookmarkNotFoundException() {
+        super(ErrorCode.BOOKMARK_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/masil/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/masil/domain/bookmark/repository/BookmarkRepository.java
@@ -1,7 +1,21 @@
 package com.masil.domain.bookmark.repository;
 
 import com.masil.domain.bookmark.entity.Bookmark;
+import com.masil.domain.member.entity.Member;
+import com.masil.domain.post.entity.Post;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+    boolean existsByPostAndMember(Post post, Member member);
+
+    Optional<Bookmark> findByPostAndMember(Post post, Member member);
+
+    @EntityGraph(attributePaths = {"post"}) // fetch 조인 후 조회
+    Slice<Bookmark> findAllByMember(Member member, Pageable pageable);
 }

--- a/src/main/java/com/masil/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/masil/domain/bookmark/repository/BookmarkRepository.java
@@ -14,8 +14,11 @@ import java.util.Optional;
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     boolean existsByPostAndMember(Post post, Member member);
 
+    boolean existsByPostAndMemberId(Post post, Long memberId);
+
     Optional<Bookmark> findByPostAndMember(Post post, Member member);
 
     @EntityGraph(attributePaths = {"post"}) // fetch 조인 후 조회
     Slice<Bookmark> findAllByMember(Member member, Pageable pageable);
+
 }

--- a/src/main/java/com/masil/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/masil/domain/bookmark/repository/BookmarkRepository.java
@@ -1,0 +1,7 @@
+package com.masil.domain.bookmark.repository;
+
+import com.masil.domain.bookmark.entity.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+}

--- a/src/main/java/com/masil/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/masil/domain/bookmark/service/BookmarkService.java
@@ -19,8 +19,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/com/masil/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/masil/domain/bookmark/service/BookmarkService.java
@@ -1,0 +1,15 @@
+package com.masil.domain.bookmark.service;
+
+import com.masil.domain.bookmark.repository.BookmarkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+}

--- a/src/main/java/com/masil/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/masil/domain/bookmark/service/BookmarkService.java
@@ -59,10 +59,6 @@ public class BookmarkService {
     public BookmarksResponse findBookmarks(Long memberId, Pageable pageable) {
         Member member = findMemberById(memberId);
         Slice<Bookmark> bookmarks = bookmarkRepository.findAllByMember(member, pageable);
-        for (Bookmark bookmark : bookmarks) {
-            System.out.println("asdasd"+bookmark);
-        }
-        System.out.println("ASDSAD"+bookmarks.getSize());
         return BookmarksResponse.ofBookmarks(bookmarks);
     }
     

--- a/src/main/java/com/masil/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/masil/domain/bookmark/service/BookmarkService.java
@@ -1,9 +1,25 @@
 package com.masil.domain.bookmark.service;
 
+import com.masil.domain.bookmark.dto.BookmarkResponse;
+import com.masil.domain.bookmark.dto.BookmarksResponse;
+import com.masil.domain.bookmark.entity.Bookmark;
+import com.masil.domain.bookmark.exception.BookmarkAlreadyExistsException;
+import com.masil.domain.bookmark.exception.BookmarkNotFoundException;
 import com.masil.domain.bookmark.repository.BookmarkRepository;
+import com.masil.domain.member.entity.Member;
+import com.masil.domain.member.exception.MemberNotFoundException;
+import com.masil.domain.member.repository.MemberRepository;
+import com.masil.domain.post.entity.Post;
+import com.masil.domain.post.exception.PostNotFoundException;
+import com.masil.domain.post.repository.PostRepository;
+import com.masil.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Service
@@ -12,4 +28,63 @@ import org.springframework.transaction.annotation.Transactional;
 public class BookmarkService {
 
     private final BookmarkRepository bookmarkRepository;
+
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public BookmarkResponse addBookmark(Long postId, Long memberId) {
+        Post post = findPostById(postId);
+        Member member = findMemberById(memberId);
+
+        validateBookmarkNotExist(post, member);
+
+        Bookmark bookmark = Bookmark.builder()
+                .post(post)
+                .member(member)
+                .build();
+        bookmarkRepository.save(bookmark);
+        return BookmarkResponse.of(true);
+    }
+
+    @Transactional
+    public BookmarkResponse deleteBookmark(Long postId, Long memberId) {
+        Post post = findPostById(postId);
+        Member member = findMemberById(memberId);
+
+        Bookmark bookmark = findBookmark(post, member);
+
+        bookmarkRepository.delete(bookmark);
+        return BookmarkResponse.of(false);
+    }
+
+    public BookmarksResponse findBookmarks(Long memberId, Pageable pageable) {
+        Member member = findMemberById(memberId);
+        Slice<Bookmark> bookmarks = bookmarkRepository.findAllByMember(member, pageable);
+        for (Bookmark bookmark : bookmarks) {
+            System.out.println("asdasd"+bookmark);
+        }
+        System.out.println("ASDSAD"+bookmarks.getSize());
+        return BookmarksResponse.ofBookmarks(bookmarks);
+    }
+    
+    private void validateBookmarkNotExist(Post post, Member member) {
+        if (bookmarkRepository.existsByPostAndMember(post, member))
+            throw new BookmarkAlreadyExistsException(ErrorCode.BOOKMARK_ALREADY_EXISTS);
+    }
+
+    private Bookmark findBookmark(Post post, Member member) {
+        return bookmarkRepository.findByPostAndMember(post, member)
+                .orElseThrow(BookmarkNotFoundException::new);
+    }
+    private Post findPostById(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(PostNotFoundException::new);
+    }
+
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+    
 }

--- a/src/main/java/com/masil/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/masil/domain/post/dto/PostDetailResponse.java
@@ -20,6 +20,7 @@ public class PostDetailResponse {
     private int likeCount;
     private Boolean isOwner;
     private Boolean isLiked;
+    private Boolean isScrap;
     private LocalDateTime createDate;
     private LocalDateTime modifyDate;
 
@@ -34,6 +35,7 @@ public class PostDetailResponse {
                 .likeCount(post.getLikeCount())
                 .isOwner(post.getIsOwner())
                 .isLiked(post.getIsLiked())
+                .isScrap(post.getIsScrap())
                 .createDate(post.getCreateDate())
                 .modifyDate(post.getModifyDate())
                 .build();

--- a/src/main/java/com/masil/domain/post/dto/PostsElementResponse.java
+++ b/src/main/java/com/masil/domain/post/dto/PostsElementResponse.java
@@ -20,6 +20,7 @@ public class PostsElementResponse {
     private int commentCount;
     private Boolean isOwner;
     private Boolean isLiked;
+    private Boolean isScrap;
     private LocalDateTime createDate;
     private LocalDateTime modifyDate;
 
@@ -35,6 +36,7 @@ public class PostsElementResponse {
                 .commentCount(post.getCommentCount())
                 .isOwner(post.getIsOwner())
                 .isLiked(post.getIsLiked())
+                .isScrap(post.getIsScrap())
                 .createDate(post.getCreateDate())
                 .modifyDate(post.getModifyDate())
                 .build();

--- a/src/main/java/com/masil/domain/post/dto/PostsResponse.java
+++ b/src/main/java/com/masil/domain/post/dto/PostsResponse.java
@@ -1,5 +1,6 @@
 package com.masil.domain.post.dto;
 
+import com.masil.domain.bookmark.entity.Bookmark;
 import com.masil.domain.post.entity.Post;
 import lombok.Getter;
 import org.springframework.data.domain.Slice;
@@ -25,4 +26,5 @@ public class PostsResponse {
 
         return new PostsResponse(postsResponse, posts.isLast());
     }
+
 }

--- a/src/main/java/com/masil/domain/post/entity/Post.java
+++ b/src/main/java/com/masil/domain/post/entity/Post.java
@@ -5,9 +5,7 @@ import com.masil.domain.board.entity.Board;
 import com.masil.domain.comment.entity.Comment;
 import com.masil.domain.member.entity.Member;
 import com.masil.global.common.entity.BaseEntity;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.Where;
 
@@ -20,7 +18,7 @@ import static javax.persistence.FetchType.LAZY;
 @Entity
 @Getter
 @SuperBuilder
-@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Where(clause = "state = 'NORMAL'")
 public class Post extends BaseEntity {
 

--- a/src/main/java/com/masil/domain/post/entity/Post.java
+++ b/src/main/java/com/masil/domain/post/entity/Post.java
@@ -65,6 +65,10 @@ public class Post extends BaseEntity {
     @Transient
     private Boolean isLiked = false;
 
+    @Builder.Default
+    @Transient
+    private Boolean isScrap = false;
+
     @Builder
     private Post(String content, Member member, State state, Board board , EmdAddress emdAddress) {
         this.content = content;
@@ -79,9 +83,10 @@ public class Post extends BaseEntity {
         this.board = board;
 
     }
-    public void updatePostPermissions(Boolean isOwner, Boolean isLiked){
+    public void updatePostPermissions(Boolean isOwner, Boolean isLiked, Boolean isScrap){
         this.isOwner = isOwner;
         this.isLiked = isLiked;
+        this.isScrap = isScrap;
     }
 
     public void tempDelete() {

--- a/src/main/java/com/masil/domain/post/service/PostService.java
+++ b/src/main/java/com/masil/domain/post/service/PostService.java
@@ -3,6 +3,7 @@ package com.masil.domain.post.service;
 import com.masil.domain.board.entity.Board;
 import com.masil.domain.board.exception.BoardNotFoundException;
 import com.masil.domain.board.repository.BoardRepository;
+import com.masil.domain.bookmark.repository.BookmarkRepository;
 import com.masil.domain.member.entity.Member;
 import com.masil.domain.member.exception.MemberNotFoundException;
 import com.masil.domain.member.repository.MemberRepository;
@@ -26,6 +27,7 @@ public class PostService {
     private final MemberRepository memberRepository;
     private final PostLikeRepository postLikeRepository;
     private final BoardRepository boardRepository;
+    private final BookmarkRepository bookmarkRepository;
 
     @Transactional
     public PostDetailResponse findDetailPost(Long postId, Long memberId) {
@@ -101,7 +103,8 @@ public class PostService {
     private void updatePostPermissionsForMember(Long memberId, Post post) {
         boolean isOwnPost = post.isOwner(memberId);
         boolean isLiked = postLikeRepository.existsByPostAndMemberId(post, memberId);
-        post.updatePostPermissions(isOwnPost, isLiked);
+        boolean isScrap = bookmarkRepository.existsByPostAndMemberId(post, memberId);
+        post.updatePostPermissions(isOwnPost, isLiked, isScrap);
     }
 
     private void checkPostState(Post post) {

--- a/src/main/java/com/masil/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/masil/global/error/exception/ErrorCode.java
@@ -25,6 +25,10 @@ public enum ErrorCode {
     // post like
     POST_NOT_SELF_LIKE(FORBIDDEN, 4001, "본인 글에는 좋아요를 누를 수 없습니다."),
 
+    // bookmark
+    BOOKMARK_ALREADY_EXISTS(BAD_REQUEST, 3301, "잘못된 요청입니다."),
+    BOOKMARK_NOT_FOUND(NOT_FOUND, 3302, "등록되지 않은 즐겨찾기입니다."),
+
     // commentLike
     COMMENT_NOT_SELF_LIKE(FORBIDDEN, 6001, "본인 댓글에는 좋아요를 누를 수 없습니다."),
 
@@ -46,9 +50,9 @@ public enum ErrorCode {
 
     INVALID_REFRESH_TOKEN(BAD_REQUEST,6003,"잘못된 리프레쉬 토큰입니다"),
 
-    UNAUTHENTICATED_LOGIN_USER(UNAUTHORIZED,6004,"로그인 유저가 존재하지 않습니다."),
+    UNAUTHENTICATED_LOGIN_USER(UNAUTHORIZED,6004,"로그인 유저가 존재하지 않습니다.");
 
-    ;
+
     private HttpStatus status;
     private final int code;
     private final String message;

--- a/src/test/java/com/masil/domain/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/masil/domain/bookmark/controller/BookmarkControllerTest.java
@@ -1,0 +1,13 @@
+package com.masil.domain.bookmark.controller;
+
+import com.masil.common.annotation.ControllerMockApiTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@WebMvcTest({
+        BookmarkController.class,
+})
+class BookmarkControllerTest extends ControllerMockApiTest {
+
+}

--- a/src/test/java/com/masil/domain/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/masil/domain/bookmark/controller/BookmarkControllerTest.java
@@ -1,13 +1,160 @@
 package com.masil.domain.bookmark.controller;
 
 import com.masil.common.annotation.ControllerMockApiTest;
+import com.masil.domain.bookmark.dto.BookmarkResponse;
+import com.masil.domain.bookmark.dto.BookmarksElementResponse;
+import com.masil.domain.bookmark.dto.BookmarksResponse;
+import com.masil.domain.bookmark.service.BookmarkService;
+import com.masil.domain.member.dto.response.MemberResponse;
+import com.masil.domain.post.dto.PostsElementResponse;
+import com.masil.domain.post.dto.PostsResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({
         BookmarkController.class,
 })
 class BookmarkControllerTest extends ControllerMockApiTest {
 
+    @MockBean
+    private BookmarkService bookmarkService;
+
+    private static final MemberResponse MEMBER_RESPONSE = MemberResponse.builder()
+            .id(1L)
+            .nickname("닉네임1")
+            .build();
+
+    private static final String AUTHORIZATION_HEADER_VALUE = "Bearer aaaaaaaa.bbbbbbbb.cccccccc";
+
+    @Test
+    @DisplayName("즐겨찾기를 성공적으로 추가한다")
+    void addBookmark() throws Exception {
+
+        // given
+        given(bookmarkService.addBookmark(any(), any())).willReturn(BookmarkResponse.of(true));
+
+        // when
+        ResultActions resultActions = requestAddBookmark("/posts/1/bookmark");
+
+        // then
+        resultActions
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("bookmark/add",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("isScrap").description("스크랩 여부")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("즐겨찾기를 성공적으로 삭제한다")
+    void deleteBookmark() throws Exception {
+
+        // given
+        given(bookmarkService.deleteBookmark(any(), any())).willReturn(BookmarkResponse.of(false));
+
+        // when
+        ResultActions resultActions = requestDeleteBookmark("/posts/1/bookmark");
+
+        // then
+        resultActions
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("bookmark/delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("isScrap").description("스크랩 여부")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("즐겨찾기를 성공적으로 조회한다")
+    void findBookmarks() throws Exception {
+
+        // given
+        List<BookmarksElementResponse> bookmarksElementResponseList = new ArrayList<>();
+
+        bookmarksElementResponseList.add(BookmarksElementResponse.builder()
+                .postId(1L)
+                .member(MEMBER_RESPONSE)
+                .boardId(1L)
+                .address("옥천동")
+                .content("내용")
+                .createDate(LocalDateTime.now())
+                .modifyDate(LocalDateTime.now())
+                .build());
+
+
+        BookmarksResponse bookmarksResponse = new BookmarksResponse(bookmarksElementResponseList, true);
+        given(bookmarkService.findBookmarks(any(), any())).willReturn(bookmarksResponse);
+
+        // when
+        ResultActions resultActions = requestFindBookmarks("/bookmarks");
+
+        // then
+        resultActions
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("bookmark/find",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("bookmarks.[].postId").description("게시글 id"),
+                                fieldWithPath("bookmarks.[].member.id").description("작성자 id"),
+                                fieldWithPath("bookmarks.[].member.nickname").description("닉네임"),
+                                fieldWithPath("bookmarks.[].boardId").description("카테고리Id"),
+                                fieldWithPath("bookmarks.[].address").description("주소"),
+                                fieldWithPath("bookmarks.[].content").description("내용"),
+                                fieldWithPath("bookmarks.[].createDate").description("생성 날짜"),
+                                fieldWithPath("bookmarks.[].modifyDate").description("수정 날짜"),
+                                fieldWithPath("isLast").description("마지막 페이지 여부")
+                        )
+                ));
+    }
+    private ResultActions requestAddBookmark(String url) throws Exception {
+        return mockMvc.perform(post(url)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+    }
+
+    private ResultActions requestDeleteBookmark(String url) throws Exception {
+        return mockMvc.perform(delete(url)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+    }
+
+    private ResultActions requestFindBookmarks(String url) throws Exception {
+        return mockMvc.perform(get(url)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+    }
 }

--- a/src/test/java/com/masil/domain/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/masil/domain/bookmark/service/BookmarkServiceTest.java
@@ -1,10 +1,143 @@
 package com.masil.domain.bookmark.service;
 
 import com.masil.common.annotation.ServiceTest;
+import com.masil.domain.address.entity.EmdAddress;
+import com.masil.domain.address.repository.EmdAddressRepository;
+import com.masil.domain.board.repository.BoardRepository;
+import com.masil.domain.bookmark.dto.BookmarkResponse;
+import com.masil.domain.bookmark.dto.BookmarksElementResponse;
+import com.masil.domain.bookmark.dto.BookmarksResponse;
+import com.masil.domain.bookmark.entity.Bookmark;
+import com.masil.domain.bookmark.exception.BookmarkAlreadyExistsException;
+import com.masil.domain.bookmark.exception.BookmarkNotFoundException;
+import com.masil.domain.bookmark.repository.BookmarkRepository;
+import com.masil.domain.member.entity.Member;
+import com.masil.domain.member.repository.MemberRepository;
+import com.masil.domain.post.entity.Post;
+import com.masil.domain.post.repository.PostRepository;
+import com.masil.domain.postlike.exception.SelfPostLikeException;
+import org.checkerframework.checker.units.qual.A;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.support.PageableExecutionUtils;
 
-import static org.junit.jupiter.api.Assertions.*;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import java.util.List;
+
+import static com.masil.domain.fixture.PostFixture.일반_게시글_JJ;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 
 class BookmarkServiceTest extends ServiceTest {
+
+    @Autowired
+    private BookmarkService bookmarkService;
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PostRepository postRepository;
+    @Autowired
+    private EmdAddressRepository emdAddressRepository;
+    @Autowired
+    private BoardRepository boardRepository;
+
+    private Member JJ;
+    private Post post1;
+    @BeforeEach
+    void setUp() {
+        post1 = 일반_게시글_JJ.엔티티_생성();
+        JJ = memberRepository.save(post1.getMember());
+        postRepository.save(post1);
+    }
+    @Test
+    @DisplayName("북마크를 성공적으로 추가한다")
+    void addBookmark_success() {
+
+        // when
+        BookmarkResponse bookmarkResponse = bookmarkService.addBookmark(post1.getId(), JJ.getId());
+
+        // then
+        Bookmark bookmark = bookmarkRepository.findById(1L).get();
+
+        assertAll(
+                () -> assertThat(bookmark.getPost()).isEqualTo(post1),
+                () -> assertThat(bookmark.getMember()).isEqualTo(JJ),
+                () ->assertThat(bookmarkResponse.getIsScrap()).isTrue()
+        );
+    }
+
+    @Test
+    @DisplayName("북마크를 추가하는데 이미 존재하는 경우 예외가 발생한다.")
+    void addBookmark_already_exists() {
+
+        // when
+        bookmarkService.addBookmark(post1.getId(), JJ.getId());
+
+        // then
+        assertThatThrownBy(() -> bookmarkService.addBookmark(post1.getId(), JJ.getId()))
+                .isInstanceOf(BookmarkAlreadyExistsException.class);
+    }
+    @Test
+    @DisplayName("북마크를 삭제한다")
+    void deleteBookmark() {
+
+        // given
+        bookmarkService.addBookmark(post1.getId(), JJ.getId());
+
+        // when
+        BookmarkResponse bookmarkResponse = bookmarkService.deleteBookmark(post1.getId(), JJ.getId());
+        Bookmark bookmark = bookmarkRepository.findByPostAndMember(post1, JJ).orElse(null);
+
+        // then
+        assertThat(bookmark).isNull();
+        assertThat(bookmarkResponse.getIsScrap()).isFalse();
+    }
+
+    @Test
+    @DisplayName("북마크를 삭제하는데 존재하지 않을 경우 예외가 발생한다.")
+    void deleteBookmark_not_found() {
+
+        // when then
+        assertThatThrownBy(() -> bookmarkService.deleteBookmark(post1.getId(), JJ.getId()))
+                .isInstanceOf(BookmarkNotFoundException.class);
+    }
+
+    @PersistenceContext
+    private EntityManager em;
+    @Test
+    @DisplayName("유저의 전체 북마크 목록을 성공적으로 조회한다.")
+    void findBookmark() {
+
+        // given TODO : emd 추후 제거
+        EmdAddress emdAddress = emdAddressRepository.findById(11110111).get();
+        List<Post> posts = 일반_게시글_JJ.엔티티_여러개_생성(emdAddress);
+        Post post = posts.get(0);
+        memberRepository.save(post.getMember());
+        boardRepository.save(post.getBoard());
+        postRepository.saveAll(posts);
+        for (Post post1 : posts) {
+            bookmarkService.addBookmark(post1.getId(), JJ.getId());
+        }
+
+        // when
+        BookmarksResponse bookmarksResponse = bookmarkService.findBookmarks(JJ.getId(), PageRequest.of(0, 8, DESC, "createDate"));
+        List<BookmarksElementResponse> bookmarks = bookmarksResponse.getBookmarks();
+
+        // then
+        assertAll(
+                () -> assertThat(bookmarksResponse.getIsLast()).isTrue(),
+                () -> assertThat(bookmarks.size()).isEqualTo(2)
+        );
+    }
 
 }

--- a/src/test/java/com/masil/domain/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/masil/domain/bookmark/service/BookmarkServiceTest.java
@@ -15,17 +15,13 @@ import com.masil.domain.member.entity.Member;
 import com.masil.domain.member.repository.MemberRepository;
 import com.masil.domain.post.entity.Post;
 import com.masil.domain.post.repository.PostRepository;
-import com.masil.domain.postlike.exception.SelfPostLikeException;
-import org.checkerframework.checker.units.qual.A;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.support.PageableExecutionUtils;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 import java.util.List;
 
@@ -112,8 +108,6 @@ class BookmarkServiceTest extends ServiceTest {
                 .isInstanceOf(BookmarkNotFoundException.class);
     }
 
-    @PersistenceContext
-    private EntityManager em;
     @Test
     @DisplayName("유저의 전체 북마크 목록을 성공적으로 조회한다.")
     void findBookmark() {

--- a/src/test/java/com/masil/domain/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/masil/domain/bookmark/service/BookmarkServiceTest.java
@@ -1,0 +1,10 @@
+package com.masil.domain.bookmark.service;
+
+import com.masil.common.annotation.ServiceTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class BookmarkServiceTest extends ServiceTest {
+
+}

--- a/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
@@ -53,6 +53,7 @@ public class PostControllerTest extends ControllerMockApiTest {
             .likeCount(0)
             .isOwner(false)
             .isLiked(false)
+            .isScrap(false)
             .createDate(LocalDateTime.now())
             .modifyDate(LocalDateTime.now())
             .build();
@@ -111,6 +112,7 @@ public class PostControllerTest extends ControllerMockApiTest {
                                 fieldWithPath("likeCount").description("좋아요 개수"),
                                 fieldWithPath("isOwner").description("본인 게시글 여부"),
                                 fieldWithPath("isLiked").description("게시글 좋아요 여부"),
+                                fieldWithPath("isScrap").description("즐겨찾기 여부"),
                                 fieldWithPath("createDate").description("생성 날짜"),
                                 fieldWithPath("modifyDate").description("수정 날짜")
                         )
@@ -157,6 +159,7 @@ public class PostControllerTest extends ControllerMockApiTest {
                 .commentCount(0)
                 .isOwner(false)
                 .isLiked(false)
+                .isScrap(false)
                 .createDate(LocalDateTime.now())
                 .modifyDate(LocalDateTime.now())
                 .build());
@@ -187,6 +190,7 @@ public class PostControllerTest extends ControllerMockApiTest {
                                 fieldWithPath("posts.[].commentCount").description("댓글 개수"),
                                 fieldWithPath("posts.[].isOwner").description("본인 글 여부"),
                                 fieldWithPath("posts.[].isLiked").description("좋아요 여부"),
+                                fieldWithPath("posts.[].isScrap").description("즐겨찾기 여부"),
                                 fieldWithPath("posts.[].createDate").description("생성 날짜"),
                                 fieldWithPath("posts.[].modifyDate").description("수정 날짜"),
                                 fieldWithPath("isLast").description("마지막 페이지 여부")

--- a/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
@@ -292,7 +292,7 @@ public class PostControllerTest extends ControllerMockApiTest {
         return mockMvc.perform(post(url)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_VALUE)
+//                        .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_VALUE)
                         .content(objectMapper.writeValueAsString(dto)))
                 .andDo(print());
     }
@@ -300,8 +300,8 @@ public class PostControllerTest extends ControllerMockApiTest {
     private ResultActions requestFindPost(String url) throws Exception {
         return mockMvc.perform(get(url)
                         .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_VALUE))
+                        .contentType(MediaType.APPLICATION_JSON))
+//                        .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_VALUE))
                 .andDo(print());
     }
 
@@ -315,15 +315,15 @@ public class PostControllerTest extends ControllerMockApiTest {
         return mockMvc.perform(patch(url)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_VALUE)
+//                        .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_VALUE)
                         .content(objectMapper.writeValueAsString(dto)))
                 .andDo(print());
     }
     private ResultActions requestDeletePost(String url) throws Exception {
         return mockMvc.perform(delete(url)
                         .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_VALUE))
+                        .contentType(MediaType.APPLICATION_JSON))
+//                        .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_VALUE))
                 .andDo(print());
     }
 

--- a/src/test/java/com/masil/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/masil/domain/post/service/PostServiceTest.java
@@ -5,6 +5,7 @@ import com.masil.domain.address.entity.EmdAddress;
 import com.masil.domain.address.repository.EmdAddressRepository;
 import com.masil.domain.board.entity.Board;
 import com.masil.domain.board.repository.BoardRepository;
+import com.masil.domain.bookmark.service.BookmarkService;
 import com.masil.domain.member.entity.Member;
 import com.masil.domain.member.repository.MemberRepository;
 import com.masil.domain.post.dto.*;
@@ -45,6 +46,8 @@ public class PostServiceTest extends ServiceTest {
     private PostLikeService postLikeService;
     @Autowired
     private EmdAddressRepository emdAddressRepository; // 임시
+    @Autowired
+    private BookmarkService bookmarkService;
 
     @PersistenceContext
     private EntityManager em;
@@ -82,7 +85,9 @@ public class PostServiceTest extends ServiceTest {
                     () -> assertThat(postDetailResponse.getBoardId()).isEqualTo(post.getBoard().getId()),
                     () -> assertThat(postDetailResponse.getContent()).isEqualTo(post.getContent()),
                     () -> assertThat(postDetailResponse.getAddress()).isEqualTo(post.getEmdAddress().getEmdName()), // 추후 수정,
-                    () -> assertThat(postDetailResponse.getIsOwner()).isEqualTo(true)
+                    () -> assertThat(postDetailResponse.getIsOwner()).isEqualTo(true),
+                    () -> assertThat(postDetailResponse.getIsLiked()).isEqualTo(false),
+                    () -> assertThat(postDetailResponse.getIsScrap()).isEqualTo(false)
             );
         }
 
@@ -126,6 +131,19 @@ public class PostServiceTest extends ServiceTest {
 
             // then
             assertThat(postDetailResponse.getIsLiked()).isEqualTo(true);
+        }
+
+        @DisplayName("즐겨찾기한 게시글을 조회한다.")
+        @Test
+        void findPost_isScrap() {
+            // given
+            bookmarkService.addBookmark(post.getId(), post.getMember().getId());
+
+            // when
+            PostDetailResponse postDetailResponse = postService.findDetailPost(post.getId(),  post.getMember().getId());
+
+            // then
+            assertThat(postDetailResponse.getIsScrap()).isEqualTo(true);
         }
 
         @Test

--- a/src/test/java/com/masil/domain/postlike/controller/PostLikeControllerTest.java
+++ b/src/test/java/com/masil/domain/postlike/controller/PostLikeControllerTest.java
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest({
         PostLikeController.class,
 })
-@AutoConfigureMockMvc(addFilters = false)
+//@AutoConfigureMockMvc(addFilters = false)
 class PostLikeControllerTest extends ControllerMockApiTest {
 
     @MockBean


### PR DESCRIPTION
# 작업 내용
즐겨찾기 기능 추가하였습니다.
db 구조는 postlike와 동일합니다. 
- memeber 1 -> N bookmark N <- post

api 요청의 경우 3가지 구현하였습니다.
- 즐겨찾기 추가
- 즐겨찾기 삭제
- 즐겨찾기 조회

post 조회시 즐겨찾기 여부인 is_scarp컬럼을 추가하였습니다.
# 참고 사항

# 스크린샷

Closes 이슈번호
#75 