### PR TITLE
refactor : 비회원 요청 가능한 인증 uri 패턴

### DIFF
--- a/src/main/java/com/masil/domain/member/controller/MemberController.java
+++ b/src/main/java/com/masil/domain/member/controller/MemberController.java
@@ -40,7 +40,7 @@ public class MemberController {
 
     @GetMapping("/login-user")
     public LoginMemberInfoResponse getMemberInfo(@LoginUser CurrentMember member) {
-        return authService.getMemberInfo(member);
+        return authService.getLoginMemberInfo(member);
     }
 
 }

--- a/src/main/java/com/masil/domain/member/service/MemberService.java
+++ b/src/main/java/com/masil/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.masil.domain.address.entity.EmdAddress;
 import com.masil.domain.address.repository.EmdAddressRepository;
 import com.masil.domain.member.dto.request.MemberAddressRequest;
 import com.masil.domain.member.entity.Member;
+import com.masil.domain.member.exception.MemberNotFoundException;
 import com.masil.domain.member.repository.MemberRepository;
 import com.masil.global.auth.repository.AuthorityRepository;
 import com.masil.global.error.exception.EntityNotFoundException;
@@ -35,7 +36,7 @@ public class MemberService {
     @Transactional
     public void modifyMemberAddress(Long memberId, MemberAddressRequest request) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+                .orElseThrow(MemberNotFoundException::new);
 
         EmdAddress emdAddress = emdAddressRepository.findById(request.getEmdId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));

--- a/src/main/java/com/masil/global/auth/controller/AuthController.java
+++ b/src/main/java/com/masil/global/auth/controller/AuthController.java
@@ -40,5 +40,4 @@ public class AuthController {
     public AuthTokenResponse reissue(@RequestBody AuthTokenRequest tokenRequest) {
         return authService.reissue(tokenRequest);
     }
-
 }

--- a/src/main/java/com/masil/global/auth/controller/AuthController.java
+++ b/src/main/java/com/masil/global/auth/controller/AuthController.java
@@ -38,6 +38,6 @@ public class AuthController {
 
     @PostMapping("/auth/reissue")
     public AuthTokenResponse reissue(@RequestBody AuthTokenRequest tokenRequest) {
-        return authService.reissue(tokenRequest);
+        return authService.reissueAccessToken(tokenRequest);
     }
 }

--- a/src/main/java/com/masil/global/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/masil/global/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,21 +1,19 @@
 package com.masil.global.auth.jwt.filter;
 
-import com.masil.global.auth.jwt.properties.JwtProperties;
 import com.masil.global.auth.jwt.provider.JwtTokenProvider;
+import com.masil.global.config.properties.AccessRequestMatcherAdaptor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.servlet.*;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.PrintWriter;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -24,16 +22,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     public static final String BEARER_PREFIX = "Bearer ";
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final AccessRequestMatcherAdaptor requestMatcherAdaptor;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
+
         // TODO: 2023/02/06 추후 변경하기  
-        String header = request.getHeader(AUTHORIZATION_HEADER);
-        if (header == null || !header.startsWith(BEARER_PREFIX) && HttpMethod.GET.equals(request.getMethod())) {
-            filterChain.doFilter(request, response);
-            return;
-        }
+//        String header = request.getHeader(AUTHORIZATION_HEADER);
+//        if (header == null || !header.startsWith(BEARER_PREFIX) && HttpMethod.GET.equals(request.getMethod())) {
+//            filterChain.doFilter(request, response);
+//            return;
+//        }
         String token = resolveToken(request);
         log.debug("token = {}", token);
 
@@ -49,10 +49,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        return request.getServletPath().startsWith("/auth");
-        /*
 
-         */
+        if (requestMatcherAdaptor.getRequestMatcher().matches(request) &&
+                request.getServletPath().startsWith("/auth") || request.getMethod().equals("GET")) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/masil/global/auth/service/AuthService.java
+++ b/src/main/java/com/masil/global/auth/service/AuthService.java
@@ -93,7 +93,7 @@ public class AuthService {
         // 리프레쉬 토큰 DB 저장
         RefreshToken savedToken;
 
-        if (isSavedRefreshToken(email)) {
+        if (isExistingRefreshToken(email)) {
             savedToken = refreshTokenRepository.findByKey(email)
                     .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
             savedToken.updateValue(refreshToken);
@@ -109,12 +109,12 @@ public class AuthService {
         return jwtTokenProvider.createTokenResponse(accessToken, refreshToken);
     }
 
-    private boolean isSavedRefreshToken(String email) {
+    private boolean isExistingRefreshToken(String email) {
         return refreshTokenRepository.findByKey(email).isPresent();
     }
 
     @Transactional
-    public AuthTokenResponse reissue(AuthTokenRequest tokenRequest) {
+    public AuthTokenResponse reissueAccessToken(AuthTokenRequest tokenRequest) {
         String orgAccessToken = tokenRequest.getAccessToken();
         String orgRefreshToken = tokenRequest.getRefreshToken();
 
@@ -178,7 +178,7 @@ public class AuthService {
     }
 
     @Transactional
-    public LoginMemberInfoResponse getMemberInfo(CurrentMember member) {
+    public LoginMemberInfoResponse getLoginMemberInfo(CurrentMember member) {
         if (member == null) {
             throw new BusinessException(ErrorCode.UNAUTHENTICATED_LOGIN_USER);
         }

--- a/src/main/java/com/masil/global/config/properties/AccessRequestMatcherAdapter.java
+++ b/src/main/java/com/masil/global/config/properties/AccessRequestMatcherAdapter.java
@@ -4,29 +4,35 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
-import org.springframework.util.AntPathMatcher;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
-public class AccessRequestMatcherAdaptor {
+public class AccessRequestMatcherAdapter implements RequestMatcher {
 
-    public RequestMatcher getRequestMatcher() {
-        AntPathMatcher pathMatcher = new AntPathMatcher();
-        pathMatcher.setCaseSensitive(false); // 대소문자 구분 안함
+    private final RequestMatcher guestAccessUri;
 
-        List<String> patterns = Arrays.asList(
+    public AccessRequestMatcherAdapter() {
+
+        List<String> accessUriPattern = Arrays.asList(
                 "/auth/**",
                 "/board/**/posts",
                 "/posts/**",
                 "/addresses/search",
                 "/posts/**/comments"
         );
-
-        return new OrRequestMatcher(patterns.stream()
+        List<RequestMatcher> requestMatchers = accessUriPattern.stream()
                 .map(pattern -> new AntPathRequestMatcher(pattern))
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList());
+
+        this.guestAccessUri = new OrRequestMatcher(requestMatchers);
+    }
+
+    @Override
+    public boolean matches(HttpServletRequest request) {
+        return guestAccessUri.matches(request);
     }
 }

--- a/src/main/java/com/masil/global/config/properties/AccessRequestMatcherAdaptor.java
+++ b/src/main/java/com/masil/global/config/properties/AccessRequestMatcherAdaptor.java
@@ -1,0 +1,32 @@
+package com.masil.global.config.properties;
+
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class AccessRequestMatcherAdaptor {
+
+    public RequestMatcher getRequestMatcher() {
+        AntPathMatcher pathMatcher = new AntPathMatcher();
+        pathMatcher.setCaseSensitive(false); // 대소문자 구분 안함
+
+        List<String> patterns = Arrays.asList(
+                "/auth/**",
+                "/board/**/posts",
+                "/posts/**",
+                "/addresses/search",
+                "/posts/**/comments"
+        );
+
+        return new OrRequestMatcher(patterns.stream()
+                .map(pattern -> new AntPathRequestMatcher(pattern))
+                .collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/com/masil/global/config/security/JwtSecurityConfig.java
+++ b/src/main/java/com/masil/global/config/security/JwtSecurityConfig.java
@@ -3,6 +3,7 @@ package com.masil.global.config.security;
 import com.masil.global.auth.jwt.filter.JwtAuthenticationFilter;
 import com.masil.global.auth.jwt.filter.JwtExceptionHandlerFilter;
 import com.masil.global.auth.jwt.provider.JwtTokenProvider;
+import com.masil.global.config.properties.AccessRequestMatcherAdaptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -13,10 +14,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
 
     private final JwtTokenProvider tokenProvider;
-
+    private final AccessRequestMatcherAdaptor requestMatcherAdaptor;
     @Override
     public void configure(HttpSecurity http) throws Exception {
-        JwtAuthenticationFilter jwtFilter = new JwtAuthenticationFilter(tokenProvider);
+        JwtAuthenticationFilter jwtFilter = new JwtAuthenticationFilter(tokenProvider, requestMatcherAdaptor);
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         http.addFilterBefore(new JwtExceptionHandlerFilter(), JwtAuthenticationFilter.class);
     }

--- a/src/main/java/com/masil/global/config/security/JwtSecurityConfig.java
+++ b/src/main/java/com/masil/global/config/security/JwtSecurityConfig.java
@@ -3,7 +3,7 @@ package com.masil.global.config.security;
 import com.masil.global.auth.jwt.filter.JwtAuthenticationFilter;
 import com.masil.global.auth.jwt.filter.JwtExceptionHandlerFilter;
 import com.masil.global.auth.jwt.provider.JwtTokenProvider;
-import com.masil.global.config.properties.AccessRequestMatcherAdaptor;
+import com.masil.global.config.properties.AccessRequestMatcherAdapter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -14,7 +14,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
 
     private final JwtTokenProvider tokenProvider;
-    private final AccessRequestMatcherAdaptor requestMatcherAdaptor;
+    private final AccessRequestMatcherAdapter requestMatcherAdaptor;
     @Override
     public void configure(HttpSecurity http) throws Exception {
         JwtAuthenticationFilter jwtFilter = new JwtAuthenticationFilter(tokenProvider, requestMatcherAdaptor);

--- a/src/main/java/com/masil/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/masil/global/config/security/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.masil.global.config.security;
 
 import com.masil.global.auth.jwt.provider.JwtTokenProvider;
-import com.masil.global.config.properties.AccessRequestMatcherAdaptor;
+import com.masil.global.config.properties.AccessRequestMatcherAdapter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,7 +30,7 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserDetailsService userDetailsService;
-    private final AccessRequestMatcherAdaptor accessRequestMatcher;
+    private final AccessRequestMatcherAdapter accessRequestMatcher;
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer(){
@@ -51,7 +51,6 @@ public class SecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
 
-                // TODO: 2023/02/06 추후 authenticate url 패턴 이야기 나누기
                 .authorizeRequests()
                 .antMatchers(
                         "/auth/**"

--- a/src/main/java/com/masil/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/masil/global/config/security/SecurityConfig.java
@@ -1,25 +1,23 @@
 package com.masil.global.config.security;
 
 import com.masil.global.auth.jwt.provider.JwtTokenProvider;
-import com.masil.global.auth.jwt.filter.JwtAuthenticationFilter;
+import com.masil.global.config.properties.AccessRequestMatcherAdaptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.config.annotation.web.servlet.configuration.EnableWebMvcSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -32,6 +30,7 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserDetailsService userDetailsService;
+    private final AccessRequestMatcherAdaptor accessRequestMatcher;
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer(){
@@ -55,18 +54,18 @@ public class SecurityConfig {
                 // TODO: 2023/02/06 추후 authenticate url 패턴 이야기 나누기
                 .authorizeRequests()
                 .antMatchers(
-                        "/auth/**",
-                        "/boards/**/posts/**",
-                        // 비회원 포스트 컨트롤러가 있고
-                        // 토큰이 필요 없는 서비스 uri 패턴만 넣어놓기
-                        "/boards/**/posts",
-                        "/posts/**/comments",
-                        "/posts/**"
-                        //
+                        "/auth/**"
                 ).permitAll()
+                .antMatchers(HttpMethod.GET,
+                        "/board/**/posts",
+                        "/posts/**",
+                        "/addresses/search",
+                        "/posts/**/comments"
+                        )
+                .permitAll()
                 .anyRequest().authenticated()
                 .and()
-                .apply(new JwtSecurityConfig(jwtTokenProvider));
+                .apply(new JwtSecurityConfig(jwtTokenProvider,accessRequestMatcher));
 
         return http.build();
     }

--- a/src/main/java/com/masil/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/masil/global/error/GlobalExceptionHandler.java
@@ -9,11 +9,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindException;
-import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   config:
     import:
-      - classpath:/backend-security/application-prod.yml
-      - classpath:/backend-security/application-test.yml
+#      - classpath:/backend-security/application-prod.yml
+#      - classpath:/backend-security/application-test.yml
   profiles:
     active: local

--- a/src/test/java/com/masil/common/annotation/ControllerMockApiTest.java
+++ b/src/test/java/com/masil/common/annotation/ControllerMockApiTest.java
@@ -4,6 +4,7 @@ package com.masil.common.annotation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.masil.common.security.WithMockCustomUser;
 import com.masil.global.auth.jwt.provider.JwtTokenProvider;
+import com.masil.global.config.properties.AccessRequestMatcherAdapter;
 import com.masil.global.config.security.SecurityConfig;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -31,4 +32,6 @@ public class ControllerMockApiTest {
     protected JwtTokenProvider jwtTokenProvider;
     @MockBean
     protected UserDetailsService userDetailsService;
+    @MockBean
+    protected AccessRequestMatcherAdapter accessRequestMatcher;
 }

--- a/src/test/java/com/masil/domain/address/controller/AddressControllerTest.java
+++ b/src/test/java/com/masil/domain/address/controller/AddressControllerTest.java
@@ -5,6 +5,7 @@ import com.masil.domain.address.dto.response.AddressSearchResponse;
 import com.masil.domain.address.service.AddressService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithAnonymousUser;
@@ -21,6 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest({
         AddressController.class,
 })
+@AutoConfigureMockMvc(addFilters = false)
 class AddressControllerTest extends ControllerMockApiTest {
 
     @MockBean

--- a/src/test/java/com/masil/domain/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/masil/domain/bookmark/controller/BookmarkControllerTest.java
@@ -5,6 +5,7 @@ import com.masil.domain.bookmark.dto.BookmarkResponse;
 import com.masil.domain.bookmark.service.BookmarkService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest({
         BookmarkController.class,
 })
+@AutoConfigureMockMvc(addFilters = false)
 class BookmarkControllerTest extends ControllerMockApiTest {
 
     @MockBean

--- a/src/test/java/com/masil/domain/postlike/controller/PostLikeControllerTest.java
+++ b/src/test/java/com/masil/domain/postlike/controller/PostLikeControllerTest.java
@@ -6,6 +6,7 @@ import com.masil.domain.postlike.exception.SelfPostLikeException;
 import com.masil.domain.postlike.service.PostLikeService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -25,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest({
         PostLikeController.class,
 })
-//@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc(addFilters = false)
 class PostLikeControllerTest extends ControllerMockApiTest {
 
     @MockBean

--- a/src/test/java/com/masil/global/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/masil/global/auth/service/AuthServiceTest.java
@@ -1,8 +1,6 @@
 package com.masil.global.auth.service;
 
-import com.masil.common.annotation.ServiceTest;
 import com.masil.domain.member.dto.request.MemberAddressRequest;
-import com.masil.domain.member.entity.Member;
 import com.masil.domain.member.repository.MemberRepository;
 import com.masil.domain.member.service.MemberService;
 import com.masil.global.auth.dto.request.LoginRequest;
@@ -23,17 +21,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.graphql.tester.AutoConfigureHttpGraphQlTester;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.HashSet;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -213,7 +205,7 @@ class AuthServiceTest {
         AuthMemberAdaptor afterAdaptor = (AuthMemberAdaptor) userDetailsService.loadUserByUsername("test1234567@naver.com");
 
         //when
-        LoginMemberInfoResponse memberInfo = authService.getMemberInfo(afterAdaptor.getMember());
+        LoginMemberInfoResponse memberInfo = authService.getLoginMemberInfo(afterAdaptor.getMember());
         //then
         assertEquals("테스트 닉네임",memberInfo.getNickname());
         assertEquals("test1234567@naver.com",memberInfo.getEmail());


### PR DESCRIPTION
# 작업 내용
SpringConfig , JWT인증 필터에 비회원 요청가능한 uri 패턴 작업 진행 
SpringConfig에 permitAll 처리 ( 해당 처리를 해도 필터체인 자체에 Jwt필터를 추가했기에 Jwt필터를 거치는 상황 그래서 JWT인증 필터에도 작업 진행 )

JWT인증필터
shouldNotFilter 메서드를 오버라이딩해서 접근 허용한 uri 패턴들 필터 거치지 않도록 처리 
/auth 엔드포인트는 회원가입 , 로그인 , 재발행 등이 있음 -> jwt필터 필요 없음
그외 엔드포인트들은 다른 httpMethod 와 겹치고 있어서 GET 메서드만 필터 거치지 않도록 진행


=> 작업하면서 스프링 시큐리티에 다중 진입점 ( 권한마다 SecurityFilterChain를 다르게 설정 ) 을 찾아냈지만 , 비회원 전용 uri 패턴이 필요해보여서 현재 진행하기 어렵다고 판단했습니다.

# 참고 사항

# 스크린샷

Closes 이슈번호
