### PR TITLE
Refactor : notification 수정

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -159,3 +159,41 @@ include::{snippets}/post/findBookmarks/http-request.adoc[]
 ==== HTTP response
 
 include::{snippets}/post/findBookmarks/http-response.adoc[]
+
+= 3. 알림
+
+== 3.1. 알림 see 연결
+
+=== 3.1.1 알림 see 연결 성공
+
+==== HTTP request
+
+include::{snippets}/notification/sse/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/notification/sse/http-response.adoc[]
+
+== 3.2. navbar 알림 조회
+
+=== 3.2.1 navbar 알림 조회 성공
+
+==== HTTP request
+
+include::{snippets}/notification/find/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/notification/find/http-response.adoc[]
+
+== 3.3. 알람 읽음 처리
+
+=== 3.3.1 알람 읽음 처리 성공
+
+==== HTTP request
+
+include::{snippets}/notification/read/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/notification/read/http-response.adoc[]

--- a/src/main/java/com/masil/domain/comment/service/CommentService.java
+++ b/src/main/java/com/masil/domain/comment/service/CommentService.java
@@ -8,6 +8,9 @@ import com.masil.domain.comment.repository.CommentRepository;
 import com.masil.domain.commentlike.repository.CommentLikeRepository;
 import com.masil.domain.member.entity.Member;
 import com.masil.domain.member.repository.MemberRepository;
+import com.masil.domain.notification.dto.NotificationDto;
+import com.masil.domain.notification.entity.NotificationType;
+import com.masil.domain.notification.service.NotificationService;
 import com.masil.domain.post.entity.Post;
 import com.masil.domain.post.exception.PostNotFoundException;
 import com.masil.domain.post.repository.PostRepository;
@@ -27,8 +30,8 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
-
     private final CommentLikeRepository commentLikeRepository;
+    private final NotificationService notificationService;
 
     /**
      * 댓글 조회
@@ -63,6 +66,7 @@ public class CommentService {
         comment.validateLength(comment.getContent());
         validateOwner(memberId, comment);
 
+        notificationService.send(member, post.getMember(), NotificationDto.of(NotificationType.POST_COMMENT_REPLY, post));
 
         return commentRepository.save(comment).getId();
     }
@@ -78,6 +82,8 @@ public class CommentService {
         Member member = findMemberById(memberId);
 
         Comment reply = childrenCreateRequest.toEntity(post, parent, member);
+
+        notificationService.send(member, parent.getMember(), NotificationDto.of(NotificationType.COMMENT_REPLY, post));
 
         return commentRepository.save(reply).getId();
     }

--- a/src/main/java/com/masil/domain/commentlike/service/CommentLikeService.java
+++ b/src/main/java/com/masil/domain/commentlike/service/CommentLikeService.java
@@ -9,6 +9,9 @@ import com.masil.domain.commentlike.exception.SelfCommentLikeException;
 import com.masil.domain.commentlike.repository.CommentLikeRepository;
 import com.masil.domain.member.entity.Member;
 import com.masil.domain.member.repository.MemberRepository;
+import com.masil.domain.notification.dto.NotificationDto;
+import com.masil.domain.notification.entity.NotificationType;
+import com.masil.domain.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,6 +28,8 @@ public class CommentLikeService {
     private final CommentRepository commentRepository;
 
     private final MemberRepository memberRepository;
+
+    private final NotificationService notificationService;
 
     @Transactional
     public CommentLikeResponse updateLikeOfComment(Long commentId, Long memberId) {
@@ -47,6 +52,8 @@ public class CommentLikeService {
     public CommentLikeResponse addLike(Comment comment, Member member) {
         CommentLike commentLike = new CommentLike(comment, member);
         commentLikeRepository.save(commentLike); // true 처리
+
+        notificationService.send(member, comment.getMember(), NotificationDto.of(NotificationType.COMMENT_LIKE, comment.getPost()));
         return CommentLikeResponse.of(comment.getLikeCount(), true);
     }
 

--- a/src/main/java/com/masil/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/masil/domain/notification/controller/NotificationController.java
@@ -26,10 +26,9 @@ public class NotificationController {
      */
     @PreAuthorize("isAuthenticated()")
     @GetMapping(value = "/sse", produces = "text/event-stream")
-    public SseEmitter createConnection(@LoginUser CurrentMember currentMember,
-                                       @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
-        log.info("sse 연결 시작, lastEventId={}", lastEventId);
-        return notificationService.createConnection(currentMember.getId(), lastEventId);
+    public SseEmitter createConnection(@LoginUser CurrentMember currentMember) {
+        log.info("sse 연결 시작");
+        return notificationService.createConnection(currentMember.getId());
     }
 
 

--- a/src/main/java/com/masil/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/masil/domain/notification/controller/NotificationController.java
@@ -11,6 +11,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.Map;
+
 
 @Slf4j
 @RequiredArgsConstructor
@@ -45,9 +47,11 @@ public class NotificationController {
      */
     @PreAuthorize("isAuthenticated()")
     @PatchMapping("/notifications/{id}")
-    public ResponseEntity<Void> readNotification(@PathVariable Long id) {
-        notificationService.readNotification(id);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<Map<String, Boolean>> readNotification(@PathVariable Long id,
+                                                                 @LoginUser CurrentMember currentMember) {
+
+        boolean isDisplay = notificationService.readNotification(id, currentMember.getId());
+        return ResponseEntity.ok(Map.of("isDisplay", isDisplay));
     }
 
 }

--- a/src/main/java/com/masil/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/masil/domain/notification/controller/NotificationController.java
@@ -8,7 +8,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.Map;

--- a/src/main/java/com/masil/domain/notification/dto/NotificationDto.java
+++ b/src/main/java/com/masil/domain/notification/dto/NotificationDto.java
@@ -19,7 +19,7 @@ public class NotificationDto {
         String content = notificationType.getMessage()
                 .replace("*", post.getNotificationPreview());
 
-        String url = "/posts/" + post.getId();
+        String url = "/post/" + post.getId();
 
         return NotificationDto.builder()
                 .notificationType(notificationType)

--- a/src/main/java/com/masil/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/masil/domain/notification/dto/NotificationResponse.java
@@ -5,7 +5,6 @@ import com.masil.domain.notification.entity.Notification;
 import lombok.Builder;
 import lombok.Getter;
 
-
 import java.time.LocalDateTime;
 
 @Getter

--- a/src/main/java/com/masil/domain/notification/dto/NotificationsResponse.java
+++ b/src/main/java/com/masil/domain/notification/dto/NotificationsResponse.java
@@ -9,18 +9,18 @@ import java.util.stream.Collectors;
 @Getter
 public class NotificationsResponse {
 
-    private List<NotificationResponse> notificationResponses;
+    private List<NotificationResponse> notifications;
 
     public NotificationsResponse(List<NotificationResponse> notificationResponses) {
-        this.notificationResponses = notificationResponses;
+        this.notifications = notificationResponses;
     }
 
     public static NotificationsResponse ofNotifications(List<Notification> notifications) {
-        List<NotificationResponse> postsResponse = notifications
+        List<NotificationResponse> notificationsResponse = notifications
                 .stream()
                 .map(notification -> NotificationResponse.of(notification))
                 .collect(Collectors.toList());
 
-        return new NotificationsResponse(postsResponse);
+        return new NotificationsResponse(notificationsResponse);
     }
 }

--- a/src/main/java/com/masil/domain/notification/entity/Notification.java
+++ b/src/main/java/com/masil/domain/notification/entity/Notification.java
@@ -57,4 +57,8 @@ public class Notification extends BaseEntity {
     public void read() {
         this.isRead = true;
     }
+
+    public boolean isOwner(Long memberId) {
+        return receiver.getId() == memberId;
+    }
 }

--- a/src/main/java/com/masil/domain/notification/exception/NotificationAccessDeniedException.java
+++ b/src/main/java/com/masil/domain/notification/exception/NotificationAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.masil.domain.notification.exception;
+
+import com.masil.global.error.exception.ErrorCode;
+import com.masil.global.error.exception.NoAuthenticationException;
+
+public class NotificationAccessDeniedException extends NoAuthenticationException {
+    public NotificationAccessDeniedException() {
+        super(ErrorCode.NOTIFICATION_ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/masil/domain/notification/exception/NotificationNotFoundException.java
+++ b/src/main/java/com/masil/domain/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,10 @@
+package com.masil.domain.notification.exception;
+
+import com.masil.global.error.exception.EntityNotFoundException;
+import com.masil.global.error.exception.ErrorCode;
+
+public class NotificationNotFoundException extends EntityNotFoundException {
+    public NotificationNotFoundException() {
+        super(ErrorCode.NOTIFICATION_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/masil/domain/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/masil/domain/notification/repository/EmitterRepository.java
@@ -1,18 +1,20 @@
 package com.masil.domain.notification.repository;
 
-import com.masil.domain.notification.entity.Notification;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.List;
 import java.util.Map;
 
 public interface EmitterRepository {
     SseEmitter save(String id, SseEmitter sseEmitter);
     
-    void saveEventCache(String id, Notification data);
+    void saveEventId(String id);
     
     void deleteById(String id);
-    
-    Map<String, Notification> findAllEventCacheStartWithById(String id);
+
+    void deleteByEventId(String id);
+
+    List<String> findEventIdsStartWithById(String id);
 
     Map<String, SseEmitter> findAllStartWithById(String id);
 }

--- a/src/main/java/com/masil/domain/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/masil/domain/notification/repository/EmitterRepository.java
@@ -9,5 +9,7 @@ public interface EmitterRepository {
     
     void deleteById(String id);
 
+    void deleteAllEmitterStartWithId(String memberId);
+
     Map<String, SseEmitter> findAllStartWithById(String id);
 }

--- a/src/main/java/com/masil/domain/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/masil/domain/notification/repository/EmitterRepository.java
@@ -2,19 +2,12 @@ package com.masil.domain.notification.repository;
 
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.util.List;
 import java.util.Map;
 
 public interface EmitterRepository {
     SseEmitter save(String id, SseEmitter sseEmitter);
     
-    void saveEventId(String id);
-    
     void deleteById(String id);
-
-    void deleteByEventId(String id);
-
-    List<String> findEventIdsStartWithById(String id);
 
     Map<String, SseEmitter> findAllStartWithById(String id);
 }

--- a/src/main/java/com/masil/domain/notification/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/com/masil/domain/notification/repository/EmitterRepositoryImpl.java
@@ -1,18 +1,19 @@
 package com.masil.domain.notification.repository;
 
-import com.masil.domain.notification.entity.Notification;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 @Repository
 public class EmitterRepositoryImpl implements EmitterRepository{
 
     private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
-    private final Map<String, Notification> eventCache = new ConcurrentHashMap<>();
+    private final List<String> eventIds = new CopyOnWriteArrayList<>();
 
     @Override
     public SseEmitter save(String id, SseEmitter sseEmitter) {
@@ -20,20 +21,24 @@ public class EmitterRepositoryImpl implements EmitterRepository{
         return sseEmitter;
     }
     @Override
-    public void saveEventCache(String id, Notification event) {
-        eventCache.put(id, event);
+    public void saveEventId(String id) {
+        eventIds.add(id);
     }
 
     @Override
     public void deleteById(String id) {
         emitters.remove(id);
     }
+    @Override
+    public void deleteByEventId(String id) {
+        eventIds.remove(id);
+    }
 
     @Override
-    public Map<String, Notification> findAllEventCacheStartWithById(String id) {
-        return eventCache.entrySet().stream()
-                .filter(entry -> entry.getKey().startsWith(id))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    public List<String> findEventIdsStartWithById(String id) {
+        return eventIds.stream()
+                .filter(eventId -> eventId.startsWith(id))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/masil/domain/notification/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/com/masil/domain/notification/repository/EmitterRepositoryImpl.java
@@ -3,42 +3,24 @@ package com.masil.domain.notification.repository;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 @Repository
 public class EmitterRepositoryImpl implements EmitterRepository{
 
     private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
-    private final List<String> eventIds = new CopyOnWriteArrayList<>();
 
     @Override
     public SseEmitter save(String id, SseEmitter sseEmitter) {
         emitters.put(id, sseEmitter);
         return sseEmitter;
     }
-    @Override
-    public void saveEventId(String id) {
-        eventIds.add(id);
-    }
 
     @Override
     public void deleteById(String id) {
         emitters.remove(id);
-    }
-    @Override
-    public void deleteByEventId(String id) {
-        eventIds.remove(id);
-    }
-
-    @Override
-    public List<String> findEventIdsStartWithById(String id) {
-        return eventIds.stream()
-                .filter(eventId -> eventId.startsWith(id))
-                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/masil/domain/notification/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/com/masil/domain/notification/repository/EmitterRepositoryImpl.java
@@ -24,10 +24,26 @@ public class EmitterRepositoryImpl implements EmitterRepository{
     }
 
     @Override
+    public void deleteAllEmitterStartWithId(String memberId) {
+        emitters.forEach((key, emitter) -> {
+            if (isEqualStartWithById(key, memberId)) {
+                emitters.remove(key);
+            }
+        });
+    }
+
+    @Override
     public Map<String, SseEmitter> findAllStartWithById(String id) {
         return emitters.entrySet().stream()
-                .filter(entry -> entry.getKey().startsWith(id))
+                .filter(entry -> isEqualStartWithById(entry.getKey(), id))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private boolean isEqualStartWithById(String emitterId, String id) {
+        int index = emitterId.indexOf("_");
+        if (index == -1)
+            return false;
+        return emitterId.substring(0, index).equals(id);
     }
 
 }

--- a/src/main/java/com/masil/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/masil/domain/notification/repository/NotificationRepository.java
@@ -2,6 +2,8 @@ package com.masil.domain.notification.repository;
 
 import com.masil.domain.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,4 +11,16 @@ import java.util.List;
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findAllByReceiverId(Long receiverId);
+
+
+    @Query(value = "SELECT count(n1.id) > 0 " +
+            "FROM notification n1 INNER JOIN (" +
+                "SELECT id FROM notification " +
+                "WHERE receiver_id = :memberId " +
+                "ORDER BY create_date DESC " +
+                "LIMIT :limit" +
+            ") n2 ON n1.id = n2.id " +
+            "WHERE n1.is_read = false;", nativeQuery = true)
+    int existsTop15UnreadByReceiverId(@Param("memberId") Long memberId, @Param("limit") int limit);
+
 }

--- a/src/main/java/com/masil/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/masil/domain/notification/repository/NotificationRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    List<Notification> findAllByReceiverId(Long receiverId);
+    List<Notification> findTop15ByReceiverIdOrderByCreateDateDesc(Long receiverId);
 
 
     @Query(value = "SELECT count(n1.id) > 0 " +

--- a/src/main/java/com/masil/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/masil/domain/notification/service/NotificationService.java
@@ -76,7 +76,7 @@ public class NotificationService {
      */
     @Transactional(readOnly = true)
     public NotificationsResponse findNotifications(Long receiverId) {
-        List<Notification> notifications = notificationRepository.findAllByReceiverId(receiverId);
+        List<Notification> notifications = notificationRepository.findTop15ByReceiverIdOrderByCreateDateDesc(receiverId);
         return NotificationsResponse.ofNotifications(notifications);
     }
 

--- a/src/main/java/com/masil/global/auth/service/AuthService.java
+++ b/src/main/java/com/masil/global/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.masil.global.auth.service;
 
 import com.masil.domain.member.entity.Member;
 import com.masil.domain.member.repository.MemberRepository;
+import com.masil.domain.notification.repository.EmitterRepository;
 import com.masil.global.auth.dto.request.AuthTokenRequest;
 import com.masil.global.auth.dto.request.LoginRequest;
 import com.masil.global.auth.dto.request.SignupRequest;
@@ -40,6 +41,7 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthorityRepository authorityRepository;
     private final PasswordEncoder passwordEncoder;
+    private final EmitterRepository emitterRepository;
 
     @Transactional
     public void signUp(SignupRequest signupRequest) {
@@ -168,6 +170,9 @@ public class AuthService {
             RefreshToken refreshToken = refreshTokenRepository.findByKey(member.getEmail())
                     .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
             refreshTokenRepository.delete(refreshToken);
+
+            // see 연결 종료
+            emitterRepository.deleteAllEmitterStartWithId(String.valueOf(memberId));
         } else {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }

--- a/src/main/java/com/masil/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/masil/global/error/exception/ErrorCode.java
@@ -49,9 +49,11 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(BAD_REQUEST,6003,"잘못된 리프레쉬 토큰입니다"),
     REFRESH_TOKEN_EXPIRED(BAD_REQUEST, 6005, "리프레쉬 토큰 유효기간이 지났습니다."),
 
-    UNAUTHENTICATED_LOGIN_USER(UNAUTHORIZED,6004,"로그인 유저가 존재하지 않습니다.");
+    UNAUTHENTICATED_LOGIN_USER(UNAUTHORIZED,6004,"로그인 유저가 존재하지 않습니다."),
 
-
+    // notification
+    NOTIFICATION_NOT_FOUND(NOT_FOUND, 7001, "존재하지 않는 알람입니다."),
+    NOTIFICATION_ACCESS_DENIED(FORBIDDEN, 7002, "해당 알람에 대한 권한이 없습니다");
     private HttpStatus status;
     private final int code;
     private final String message;

--- a/src/test/java/com/masil/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/masil/domain/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,152 @@
+package com.masil.domain.notification.controller;
+
+import com.masil.common.annotation.ControllerMockApiTest;
+import com.masil.domain.bookmark.dto.BookmarkResponse;
+import com.masil.domain.member.dto.response.MemberResponse;
+import com.masil.domain.notification.dto.NotificationResponse;
+import com.masil.domain.notification.dto.NotificationsResponse;
+import com.masil.domain.notification.entity.Notification;
+import com.masil.domain.notification.service.NotificationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest({
+        NotificationController.class,
+})
+@AutoConfigureMockMvc(addFilters = false)
+public class NotificationControllerTest extends ControllerMockApiTest {
+
+    @MockBean
+    private NotificationService notificationService;
+
+    private static final String AUTHORIZATION_HEADER_VALUE = "Bearer aaaaaaaa.bbbbbbbb.cccccccc";
+
+    private static final MemberResponse MEMBER_RESPONSE = MemberResponse.builder()
+            .id(1L)
+            .nickname("닉네임1")
+            .build();
+
+    @Test
+    @DisplayName("sse 연결을 성공한다.")
+    void createConnection() throws Exception {
+
+        // given
+        given(notificationService.createConnection(any())).willReturn(new SseEmitter());
+
+        // when
+        ResultActions resultActions = requestCreateConnection("/sse");
+
+        // then
+        resultActions
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("notification/sse",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ));
+    }
+
+    @Test
+    @DisplayName("알람 조회 요청을 성공한다.")
+    void findNotifications() throws Exception {
+
+        // given
+        List<NotificationResponse> notifications = new ArrayList<>();
+        notifications.add(NotificationResponse.builder()
+                .id(1L)
+                .sender(MEMBER_RESPONSE)
+                .content("님이 게시글내용어쩌구저쩌구...에 좋아요를 하였습니다.")
+                .url("/post/1")
+                .isRead(false)
+                .createDate(LocalDateTime.now())
+                .build());
+        NotificationsResponse notificationsResponse = new NotificationsResponse(notifications);
+        given(notificationService.findNotifications(any())).willReturn(notificationsResponse);
+
+        // when
+        ResultActions resultActions = requestFindNotifications("/notifications");
+
+        // then
+        resultActions
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("notification/find",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("notifications.[].id").description("알람 id"),
+                                fieldWithPath("notifications.[].sender.id").description("발신자 id"),
+                                fieldWithPath("notifications.[].sender.nickname").description("발신자 닉네임"),
+                                fieldWithPath("notifications.[].content").description("알람 내용"),
+                                fieldWithPath("notifications.[].url").description("발생된 url"),
+                                fieldWithPath("notifications.[].isRead").description("알람 읽음 여부"),
+                                fieldWithPath("notifications.[].createDate").description("생성 날짜")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("알람 읽음 요청을 성공한다.")
+    void readNotification() throws Exception {
+
+        // given
+        given(notificationService.readNotification(any(), any())).willReturn(true);
+
+        // when
+        ResultActions resultActions = requestReadNotification("/notifications/1");
+
+        // then
+        resultActions
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("notification/read",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("isDisplay").description("알람 표시 여부")
+                        )
+                ));
+    }
+    private ResultActions requestCreateConnection(String url) throws Exception {
+        return mockMvc.perform(get(url)
+                        .accept(MediaType.TEXT_EVENT_STREAM)
+                        .contentType(MediaType.TEXT_EVENT_STREAM)
+                        .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_VALUE))
+                .andDo(print());
+    }
+
+    private ResultActions requestFindNotifications(String url) throws Exception {
+        return mockMvc.perform(get(url)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_VALUE))
+                .andDo(print());
+    }
+
+    private ResultActions requestReadNotification(String url) throws Exception {
+        return mockMvc.perform(patch(url)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_VALUE))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/masil/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/masil/domain/notification/controller/NotificationControllerTest.java
@@ -1,11 +1,9 @@
 package com.masil.domain.notification.controller;
 
 import com.masil.common.annotation.ControllerMockApiTest;
-import com.masil.domain.bookmark.dto.BookmarkResponse;
 import com.masil.domain.member.dto.response.MemberResponse;
 import com.masil.domain.notification.dto.NotificationResponse;
 import com.masil.domain.notification.dto.NotificationsResponse;
-import com.masil.domain.notification.entity.Notification;
 import com.masil.domain.notification.service.NotificationService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,10 +23,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/com/masil/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/masil/domain/notification/service/NotificationServiceTest.java
@@ -110,7 +110,7 @@ class NotificationServiceTest extends ServiceTest {
 
         // when
         NotificationsResponse notifications = notificationService.findNotifications(JJ.getId());
-        List<NotificationResponse> notificationResponses = notifications.getNotificationResponses();
+        List<NotificationResponse> notificationResponses = notifications.getNotifications();
         NotificationResponse notificationResponse = notificationResponses.get(0);
 
         // then

--- a/src/test/java/com/masil/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/masil/domain/notification/service/NotificationServiceTest.java
@@ -87,7 +87,7 @@ class NotificationServiceTest extends ServiceTest {
     }
 
     @Test
-    @DisplayName("알림 목록 조회를 성공한다.")
+    @DisplayName("최신 알림 목록 조회를 성공한다.")
     void findNotifications_success() {
         /**
          * KK가 JJ의 게시글을 좋아요를 할 경우
@@ -105,7 +105,9 @@ class NotificationServiceTest extends ServiceTest {
         Member KK = MemberFixture.일반_회원_KK.엔티티_생성();
         memberRepository.save(KK);
 
-        postLikeService.toggleLikePost(post.getId(), KK.getId());
+        for (int i = 0; i < 40; i++) {
+            postLikeService.toggleLikePost(post.getId(), KK.getId());
+        }
 
         // when
         NotificationsResponse notifications = notificationService.findNotifications(JJ.getId());
@@ -113,8 +115,9 @@ class NotificationServiceTest extends ServiceTest {
         NotificationResponse notificationResponse = notificationResponses.get(0);
 
         // then
+        assertThat(notificationResponses.size()).isEqualTo(15);
         assertThat(notificationResponse.getIsRead()).isFalse();
-        assertThat(notificationResponse.getId()).isEqualTo(1L);
+        assertThat(notificationResponse.getId()).isEqualTo(20L);
         assertThat(notificationResponse.getSender().getId()).isEqualTo(KK.getId());
     }
 
@@ -148,5 +151,4 @@ class NotificationServiceTest extends ServiceTest {
         assertThat(notification.getIsRead()).isTrue();
         assertThat(isDisplay).isFalse();
     }
-
 }

--- a/src/test/java/com/masil/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/masil/domain/notification/service/NotificationServiceTest.java
@@ -48,10 +48,9 @@ class NotificationServiceTest extends ServiceTest {
     void createConnection_success() {
         //given
         Member member = MemberFixture.일반_회원_JJ.엔티티_생성();
-        String lastEventId = "";
 
         // when
-        SseEmitter subscribe = notificationService.createConnection(member.getId(), lastEventId);
+        SseEmitter subscribe = notificationService.createConnection(member.getId());
 
         // then
         assertThat(subscribe).isNotNull();

--- a/src/test/java/com/masil/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/masil/domain/notification/service/NotificationServiceTest.java
@@ -42,6 +42,7 @@ class NotificationServiceTest extends ServiceTest {
     @Autowired
     private EmdAddressRepository emdAddressRepository;
 
+
     @Test
     @DisplayName("클라이언트의 알림 연결을 성공한다.")
     void createConnection_success() {
@@ -140,11 +141,12 @@ class NotificationServiceTest extends ServiceTest {
         postLikeService.toggleLikePost(post.getId(), KK.getId());
 
         // when
-        notificationService.readNotification(1L);
+        boolean isDisplay = notificationService.readNotification(1L, JJ.getId());
 
         // then
         Notification notification = notificationRepository.findById(1L).get();
         assertThat(notification.getIsRead()).isTrue();
+        assertThat(isDisplay).isFalse();
     }
 
 }

--- a/src/test/java/com/masil/global/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/masil/global/auth/service/AuthServiceTest.java
@@ -52,8 +52,8 @@ class AuthServiceTest {
     @Autowired
     private RefreshTokenRepository refreshTokenRepository;
 
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+//    @Autowired
+//    private PasswordEncoder passwordEncoder;
 
     @BeforeEach
     void saveAuthority() {


### PR DESCRIPTION
# 작업 내용

중간에 작업 내용이 많이 바뀌어서 
ecce53e 커밋 내역은 건너뛰시면 됩니다.

- 새로 구현한 기능
  - 알람 읽음 처리에 대한 로직 구현하였습니다. 읽음 처리를 한 뒤에 알림 표시여부를 반환해 주도록 하였습니다.
  - 좋아요 이외에 알림을 추가하였습니다.
    - 댓글 알림, 대댓글 알림, 댓글 좋아요 알림 추가
   - 로그아웃시 sse연결 종료되도록 구현하였습니다.
   - controller 테스트 구현하였습니다.
  ---
- 개선 사항
  - 알림 조회 요구사항에 맞게 수정해주었습니다.
  - sse연결과 알림 전송 기능이 크게 바뀌었습니다.
    - 기존 실시간으로 알람 데이터를 클라이언트에 전송하는 방식에서 알람 데이터가 아닌 알람표시 여부만 전송하도록 수정하였습니다.
    - 실질적인 기능은 알림이 생길 경우 실시간으로 종 아이콘에 표시가 뜨는 정도 입니다. 



Closes 이슈번호
#99 