### PR TITLE
bug : 전체 카테고리 제대로 조회되도록 수정

### DIFF
--- a/src/main/java/com/masil/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/masil/domain/post/repository/PostRepository.java
@@ -16,7 +16,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 //            + "or "
 //            + "(content regexp :query) ";
 
+    Slice<Post> findAllByEmdAddressId(Integer rCode, Pageable pageable);
+
     Slice<Post> findAllByBoardIdAndEmdAddressId(Long boardId, Integer emdAddressId, Pageable pageable);
+
+    Slice<Post> findAllByEmdAddressSggAddressId(Integer rCode, Pageable pageable);
 
     Slice<Post> findAllByBoardIdAndEmdAddressSggAddressId(Long boardId, Integer sggAddressId, Pageable pageable);
 
@@ -27,4 +31,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Modifying
     @Query(value = "UPDATE Post p set p.viewCount = p.viewCount + 1 where p.id = :postId")
     void increaseViewCount(Long postId);
+
 }

--- a/src/main/java/com/masil/domain/post/service/PostService.java
+++ b/src/main/java/com/masil/domain/post/service/PostService.java
@@ -34,6 +34,7 @@ import javax.annotation.Nullable;
 public class PostService {
 
     private static final int MIN_LENGTH = 2;
+    private static final int ALL_CATEGORY = 1;
 
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
@@ -128,10 +129,16 @@ public class PostService {
     }
 
     private Slice<Post> findAllPostBySggId(PostFilterRequest request) {
+        if (request.getBoardId() == ALL_CATEGORY) {
+            return postRepository.findAllByEmdAddressSggAddressId(request.getRCode(), request.getPageable());
+        }
         return postRepository.findAllByBoardIdAndEmdAddressSggAddressId(request.getBoardId(), request.getRCode(), request.getPageable());
     }
 
     private Slice<Post> findAllPostByEmdId(PostFilterRequest request) {
+        if (request.getBoardId() == ALL_CATEGORY) {
+            return postRepository.findAllByEmdAddressId(request.getRCode(), request.getPageable());
+        }
         return postRepository.findAllByBoardIdAndEmdAddressId(request.getBoardId(), request.getRCode(), request.getPageable());
     }
 

--- a/src/test/java/com/masil/domain/post/dto/PostFilterRequestBuilder.java
+++ b/src/test/java/com/masil/domain/post/dto/PostFilterRequestBuilder.java
@@ -9,4 +9,8 @@ public class PostFilterRequestBuilder {
     public static PostFilterRequest build() {
         return new PostFilterRequest(1L, 11110111, PageRequest.of(0, 8, DESC, "createDate"));
     }
+
+    public static PostFilterRequest build(Long boardId) {
+        return new PostFilterRequest(boardId, 11110111, PageRequest.of(0, 8, DESC, "createDate"));
+    }
 }

--- a/src/test/java/com/masil/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/masil/domain/post/service/PostServiceTest.java
@@ -208,6 +208,20 @@ public class PostServiceTest extends ServiceTest {
             );
         }
 
+        @Test
+        @DisplayName("카테고리가 2인 게시글은 없다.")
+        void findPosts_no_post_with_boardId2() {
+            // given
+            PostFilterRequest postFilterRequest = PostFilterRequestBuilder.build(2L);
+
+            // when
+            PostsResponse postsResponse = postService.findPosts(postFilterRequest, post.getMember().getId());
+            List<PostsElementResponse> postsElementResponseList = postsResponse.getPosts();
+
+            // then
+            assertThat(postsElementResponseList.size()).isEqualTo(0);
+        }
+
         @DisplayName("상태가 DELETE 인 게시글은 제외하고 조회한다.")
         @Test
         void findPosts_isDeleted() {


### PR DESCRIPTION
# 작업 내용
카테고리 id가 1로 넘어올 경우 전체게시글 반환되도록 수정하였습니다.


Closes 이슈번호
#103 