### PR TITLE
Refactor : 자잘한 리펙토링

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -160,18 +160,6 @@ include::{snippets}/bookmark/delete/http-request.adoc[]
 
 include::{snippets}/bookmark/delete/http-response.adoc[]
 
-== 2.3. 즐겨찾기 조회하기
-
-=== 2.3.1 즐겨찾기 조회하기 성공
-
-==== HTTP request
-
-include::{snippets}/post/findBookmarks/http-request.adoc[]
-
-==== HTTP response
-
-include::{snippets}/post/findBookmarks/http-response.adoc[]
-
 = 3. 알림
 
 == 3.1. 알림 see 연결

--- a/src/main/java/com/masil/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/masil/domain/bookmark/repository/BookmarkRepository.java
@@ -19,8 +19,5 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findByPostAndMember(Post post, Member member);
 
     @EntityGraph(attributePaths = {"post"}) // fetch 조인 후 조회
-    Slice<Bookmark> findAllByMemberAndPostState(Member member, State state, Pageable pageable);
-
-    @EntityGraph(attributePaths = {"post"}) // fetch 조인 후 조회
     Slice<Bookmark> findAllByMemberIdAndPostState(Long memberId, State state, Pageable pageable);
 }

--- a/src/main/java/com/masil/domain/comment/service/CommentService.java
+++ b/src/main/java/com/masil/domain/comment/service/CommentService.java
@@ -69,6 +69,7 @@ public class CommentService {
         comment.validateLength(comment.getContent());
         validateOwner(memberId, comment);
 
+        post.increaseComment();
         notificationService.send(member, post.getMember(), NotificationDto.of(NotificationType.POST_COMMENT_REPLY, post));
 
         return commentRepository.save(comment).getId();
@@ -86,6 +87,7 @@ public class CommentService {
 
         Comment reply = childrenCreateRequest.toEntity(post, parent, member);
 
+        post.increaseComment();
         notificationService.send(member, parent.getMember(), NotificationDto.of(NotificationType.COMMENT_REPLY, post));
 
         return commentRepository.save(reply).getId();
@@ -113,12 +115,12 @@ public class CommentService {
     public void deleteComment(Long postId, Long commentId, Long memberId) {
         Comment comment = findCommentById(commentId);
         findMemberById(memberId);
-        findPostById(postId);
+        Post post = findPostById(postId);
 
         validateOwner(memberId, comment);
 
         comment.tempDelete();
-
+        post.decreaseLike();
     }
 
     /**

--- a/src/main/java/com/masil/domain/post/controller/PostController.java
+++ b/src/main/java/com/masil/domain/post/controller/PostController.java
@@ -84,16 +84,6 @@ public class PostController {
         return ResponseEntity.noContent().build();
     }
 
-    @PreAuthorize("isAuthenticated()")
-    @GetMapping("/bookmarks")
-    public ResponseEntity<PostsResponse> findBookmarks(@LoginUser CurrentMember currentMember,
-                                                       @PageableDefault(sort = "createDate", direction = DESC) Pageable pageable) {
-        log.info("즐겨찾기 목록 조회 시작");
-
-        PostsResponse postsResponse = postService.findBookmarks(currentMember.getId(), pageable);
-        return ResponseEntity.ok(postsResponse);
-    }
-
     /**
      * 게시글 검색
      */

--- a/src/main/java/com/masil/domain/post/entity/Post.java
+++ b/src/main/java/com/masil/domain/post/entity/Post.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
@@ -65,6 +66,7 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post")
     private List<Comment> comments = new ArrayList<>();
 
+    @BatchSize(size=100)
     @Builder.Default
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostFile> postFiles = new ArrayList<>();

--- a/src/main/java/com/masil/domain/post/entity/Post.java
+++ b/src/main/java/com/masil/domain/post/entity/Post.java
@@ -42,6 +42,9 @@ public class Post extends BaseEntity {
     @Column(columnDefinition = "integer default 0", nullable = false)
     private int likeCount;
 
+    @Column(columnDefinition = "integer default 0", nullable = false)
+    private int commentCount;
+
     @Builder.Default
     @Enumerated(EnumType.STRING)
     private State state = State.NORMAL;
@@ -106,17 +109,18 @@ public class Post extends BaseEntity {
         return this.member.getId() == memberId;
     }
 
-    public void plusLike() {
+    public void increaseLike() {
         this.likeCount++;
     }
-    public void minusLike() {
+    public void decreaseLike() {
         this.likeCount--;
     }
-    public int getCommentCount() {
-        if (comments == null) {
-            return 0;
-        }
-        return comments.size();
+
+    public void increaseComment() {
+        this.commentCount++;
+    }
+    public void decreaseComment() {
+        this.commentCount--;
     }
 
     public boolean isDeleted() {

--- a/src/main/java/com/masil/domain/post/service/PostService.java
+++ b/src/main/java/com/masil/domain/post/service/PostService.java
@@ -107,17 +107,6 @@ public class PostService {
         post.tempDelete();
     }
 
-    public PostsResponse findBookmarks(Long memberId, Pageable pageable) {
-        Member member = findMemberById(memberId);
-        Slice<Bookmark> bookmarks = bookmarkRepository.findAllByMemberAndPostState(member, State.NORMAL, pageable);
-
-        for (Bookmark bookmark : bookmarks) {
-            updatePostPermissionsForMember(memberId, bookmark.getPost());
-        }
-
-        return PostsResponse.ofBookmarks(bookmarks);
-    }
-
     /**
      * 검색 쿼리 추가
      */

--- a/src/main/java/com/masil/domain/post/service/PostService.java
+++ b/src/main/java/com/masil/domain/post/service/PostService.java
@@ -6,7 +6,6 @@ import com.masil.domain.board.repository.BoardRepository;
 import com.masil.domain.bookmark.entity.Bookmark;
 import com.masil.domain.bookmark.repository.BookmarkRepository;
 import com.masil.domain.member.dto.request.MyFindRequest;
-import com.masil.domain.member.dto.response.MyFindResponse;
 import com.masil.domain.member.entity.Member;
 import com.masil.domain.member.exception.MemberNotFoundException;
 import com.masil.domain.member.repository.MemberRepository;
@@ -28,7 +27,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 
 import javax.annotation.Nullable;
 

--- a/src/main/java/com/masil/domain/post/service/PostService.java
+++ b/src/main/java/com/masil/domain/post/service/PostService.java
@@ -3,7 +3,6 @@ package com.masil.domain.post.service;
 import com.masil.domain.board.entity.Board;
 import com.masil.domain.board.exception.BoardNotFoundException;
 import com.masil.domain.board.repository.BoardRepository;
-import com.masil.domain.bookmark.entity.Bookmark;
 import com.masil.domain.bookmark.repository.BookmarkRepository;
 import com.masil.domain.member.dto.request.MyFindRequest;
 import com.masil.domain.member.entity.Member;
@@ -12,13 +11,14 @@ import com.masil.domain.member.repository.MemberRepository;
 import com.masil.domain.post.dto.*;
 import com.masil.domain.post.entity.Post;
 import com.masil.domain.post.entity.SearchQuery;
-import com.masil.domain.post.entity.State;
 import com.masil.domain.post.exception.PostAccessDeniedException;
 import com.masil.domain.post.exception.PostNotFoundException;
 import com.masil.domain.post.exception.PostSearchInputException;
 import com.masil.domain.post.repository.PostRepository;
+import com.masil.domain.postFile.entity.PostFile;
 import com.masil.domain.postFile.repository.PostFileRepository;
 import com.masil.domain.postlike.repository.PostLikeRepository;
+import com.masil.domain.storage.exception.InvalidImageFileException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -77,11 +78,14 @@ public class PostService {
         Board board = findBoardById(postCreateRequest.getBoardId());
         Post post = postCreateRequest.toEntity(member, board);
 
-        // TODO : update 문 여러번 발생함, 추후 개선
-        postFileRepository.findByIdIn(postCreateRequest.getFileIds())
-                .stream()
-                .forEach(postFile -> post.addPostFiles(postFile));
+        List<PostFile> postFiles = postFileRepository.findByIdIn(postCreateRequest.getFileIds());
 
+        for (PostFile postFile : postFiles) {
+            // 이미 이미지의 주인이 있는 경우 예외 반환
+            if (postFile.getPost() != null)
+                throw new InvalidImageFileException();
+            post.addPostFiles(postFile);
+        }
 
         return postRepository.save(post).getId();
     }

--- a/src/main/java/com/masil/domain/postlike/service/PostLikeService.java
+++ b/src/main/java/com/masil/domain/postlike/service/PostLikeService.java
@@ -56,14 +56,14 @@ public class PostLikeService {
                 .member(member)
                 .build();
         postLikeRepository.save(newPostLike);
-        post.plusLike();
+        post.increaseLike();
         notificationService.send(member, post.getMember(), NotificationDto.of(NotificationType.POST_LIKE, post));
         return PostLikeResponse.of(post.getLikeCount(), true);
     }
 
     private PostLikeResponse deletePostLike(Post post, PostLike postLike) {
         postLikeRepository.delete(postLike);
-        post.minusLike();
+        post.decreaseLike();
         return PostLikeResponse.of(post.getLikeCount(), false);
     }
 

--- a/src/main/java/com/masil/global/common/entity/BaseEntity.java
+++ b/src/main/java/com/masil/global/common/entity/BaseEntity.java
@@ -10,6 +10,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
@@ -26,6 +27,7 @@ import static lombok.AccessLevel.PROTECTED;
 public class BaseEntity {
 
     @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createDate;
 
     @LastModifiedDate

--- a/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/masil/domain/post/controller/PostControllerTest.java
@@ -310,67 +310,6 @@ public class PostControllerTest extends ControllerMockApiTest {
     }
 
     @Test
-    @DisplayName("즐겨찾기를 성공적으로 조회한다")
-    void findBookmarks() throws Exception {
-
-        // given
-        List<PostsElementResponse> postsElementResponseList = new ArrayList<>();
-
-        postsElementResponseList.add(PostsElementResponse.builder()
-                .id(1L)
-                .member(MEMBER_RESPONSE)
-                .boardId(1L)
-                .address("옥천동")
-                .content("내용")
-                .viewCount(0)
-                .likeCount(0)
-                .commentCount(0)
-                .isOwner(false)
-                .isLiked(false)
-                .isScrap(false)
-                .createDate(LocalDateTime.now())
-                .modifyDate(LocalDateTime.now())
-                .thumbnail(FILE_RESPONSE)
-                .build());
-
-
-        PostsResponse postsResponse = new PostsResponse(postsElementResponseList, true);
-        given(postService.findBookmarks(any(), any())).willReturn(postsResponse);
-
-        // when
-        ResultActions resultActions = requestFindBookmarks("/bookmarks");
-
-        // then
-        resultActions
-                .andExpect(status().is2xxSuccessful())
-                .andDo(document("post/findBookmarks",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        responseFields(
-                                fieldWithPath("posts.[].id").description("게시글 id"),
-                                fieldWithPath("posts.[].member.id").description("작성자 id"),
-                                fieldWithPath("posts.[].member.nickname").description("닉네임"),
-                                fieldWithPath("posts.[].boardId").description("카테고리Id"),
-                                fieldWithPath("posts.[].address").description("주소"),
-                                fieldWithPath("posts.[].content").description("내용"),
-                                fieldWithPath("posts.[].viewCount").description("조회수"),
-                                fieldWithPath("posts.[].likeCount").description("좋아요 개수"),
-                                fieldWithPath("posts.[].commentCount").description("댓글 개수"),
-                                fieldWithPath("posts.[].isOwner").description("본인 글 여부"),
-                                fieldWithPath("posts.[].isLiked").description("좋아요 여부"),
-                                fieldWithPath("posts.[].isScrap").description("즐겨찾기 여부"),
-                                fieldWithPath("posts.[].createDate").description("생성 날짜"),
-                                fieldWithPath("posts.[].modifyDate").description("수정 날짜"),
-                                fieldWithPath("posts.[].thumbnail.url").description("이미지 주소"),
-                                fieldWithPath("posts.[].thumbnail.width").description("너비"),
-                                fieldWithPath("posts.[].thumbnail.height").description("높이"),
-                                fieldWithPath("isLast").description("마지막 페이지 여부")
-                        )
-                ));
-
-    }
-
-    @Test
     @DisplayName("게시글 검색 조회를 성공한다.")
     void searchPost_success() throws Exception {
         // given

--- a/src/test/java/com/masil/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/masil/domain/post/service/PostServiceTest.java
@@ -370,58 +370,5 @@ public class PostServiceTest extends ServiceTest {
                     .isInstanceOf(PostAccessDeniedException.class);
         }
     }
-    @Nested
-    @DisplayName("유저가 북마크한 게시글 목록 조회를 할 때")
-    class FindBookmarks {
-
-        private List<Post> posts;
-        private Post post;
-        private Member JJ;
-
-        @BeforeEach
-        void setUp() {
-            // TODO : emd 추후 제거
-            EmdAddress emdAddress = emdAddressRepository.findById(11110111).get();
-            posts = 일반_게시글_JJ.엔티티_여러개_생성(emdAddress);
-            post = posts.get(0);
-
-            JJ = memberRepository.save(post.getMember());
-            boardRepository.save(post.getBoard());
-            postRepository.saveAll(posts);
-        }
-        @Test
-        @DisplayName("성공적으로 조회한다.")
-        void findBookmarks_success() {
-
-            // given
-            bookmarkService.addBookmark(post.getId(), JJ.getId());
-
-            // when
-            PostsResponse postsResponse = postService.findBookmarks(JJ.getId(), PageRequest.of(0, 8, DESC, "createDate"));
-            PostsElementResponse postsElementResponse = postsResponse.getPosts().get(0);
-
-            // then
-            assertAll(
-                    () -> assertThat(postsResponse.getPosts().size()).isEqualTo(1),
-                    () -> assertThat(postsElementResponse.getId()).isEqualTo(post.getId()),
-                    () -> assertThat(postsResponse.getIsLast()).isTrue()
-            );
-        }
-
-        @Test
-        @DisplayName("상태가 DELETE 인 게시글은 제외하고 조회한다.")
-        void findBookmarks_isDeleted() {
-            // given
-            bookmarkService.addBookmark(post.getId(), JJ.getId());
-            postService.deletePost(post.getId(), JJ.getId());
-
-            // when
-            PostsResponse postsResponse = postService.findBookmarks(JJ.getId(), PageRequest.of(0, 8, DESC, "createDate"));
-
-            // then
-            assertThat(postsResponse.getPosts().size()).isEqualTo(0);
-        }
-
-    }
 
 }


### PR DESCRIPTION
# 작업 내용
- post엔티티에 commentCount추가
  - 댓글 추가 및 삭제시 commentCount 관련 로직 추가
- @BatchSize로 기존 N+1 문제 해결
- 기존 즐겨찾기 목록 조회 삭제
- 생성날짜 수정 불가하도록 어노테이션 추가
- 게시글 이미지 관련 예외처리 추가

# 참고사항
commentCount 컬럼 추가로 기존 댓글 데이터 삭제 혹은 수정해줘야 될 겁니다.

Closes 이슈번호
#118 